### PR TITLE
ETLP-10: adds repository text handling rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Normalize text files to LF in the index and on checkout for stable diffs.
+* text=auto eol=lf
+
+# Source, configuration, documentation, and script files are always LF text.
+*.py text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.json text eol=lf
+*.sh text eol=lf
+*.bash text eol=lf
+*.zsh text eol=lf
+
+# Repository metadata should remain LF across platforms.
+.gitignore text eol=lf
+.gitattributes text eol=lf
+.editorconfig text eol=lf
+
+# Binary assets must not be normalized or treated as text.
+*.png binary -eol
+*.jpg binary -eol
+*.jpeg binary -eol
+*.gif binary -eol
+*.pdf binary -eol
+*.zip binary -eol


### PR DESCRIPTION
<!--
planning_metadata:
  estimated_effort: 0.5h
  priority: Medium
  milestone_id: 0
  milestone: "0. Repository Execution Foundation"
-->

## Summary
Add repository-level text, line-ending, and file-handling rules through a .gitattributes file.

## Should have
- Add .gitattributes at repository root
- Enforce LF line endings for source, configuration, and documentation files
- Document binary file handling where appropriate
- Ensure checkout and commit behaviour is predictable across platforms

## Nice to have
- Add comments explaining the intent of each rule

## Acceptance criteria
- [x] .gitattributes exists at repository root
- [x] Text and source files use predictable line-ending rules
- [x] Rules are understandable for future contributors and AI coding agents
