### PR TITLE
ETLP-14: documents canonical attendance event schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Extract -> Transform/Canonicalise -> Publish -> Process -> Store/Review
 
 - Extract: the ingestion client connects to the ZKTeco device and retrieves users and attendance records.
 - Transform/Canonicalise: current code decodes device records into Python dictionaries containing timestamp,
-  employee name, device identifier, and entry type. A more explicit canonical attendance event schema remains
-  future work.
+  employee name, device identifier, and entry type. The target canonical attendance event contract is documented
+  in [Canonical Attendance Event](docs/data-contracts/canonical-attendance-event.md).
 - Publish: the ingestion client publishes JSON payloads to Google Cloud Pub/Sub topics for review-period,
   review-sheet, and attendance-record workflows.
 - Process: Google Cloud Function modules under `attendance_etl.functions` process Pub/Sub events and coordinate
@@ -98,7 +98,7 @@ The repository currently contains:
 Near-term work should stay focused on making the existing ETL system easier to reason about, test, and
 extend:
 
-- Define a canonical attendance event schema.
+- Adopt the canonical attendance event schema across transformation and downstream processing.
 - Document architecture and data contracts.
 - Add focused tests around ingestion and function behavior.
 - Isolate the transformation layer.
@@ -116,4 +116,5 @@ For setup, dependency installation, validation commands, and contribution workfl
 Key repository references:
 
 - [Agent operating instructions](AGENTS.md)
+- [Canonical attendance event contract](docs/data-contracts/canonical-attendance-event.md)
 - [CI workflow](.github/workflows/ci.yml)

--- a/docs/data-contracts/canonical-attendance-event.md
+++ b/docs/data-contracts/canonical-attendance-event.md
@@ -1,0 +1,64 @@
+# Canonical Attendance Event
+
+The canonical attendance event is the normalised internal representation of one attendance record.
+It is produced after extraction and ingestion, during transformation/canonicalisation, and is intended
+for downstream publication, processing, and storage.
+
+This contract describes the target canonical payload shape. Current device-specific decoding may still
+emit transitional fields until transformation work adopts this contract end to end.
+
+## Schema
+
+| field | type | required/optional | description | example |
+| --- | --- | --- | --- | --- |
+| `event_id` | string | required | Canonical event identifier. It should be deterministic when the source guarantees uniqueness; otherwise it is generated during transformation/canonicalisation. | `att-dev-dk-01-10042-2026-05-27T08:59:12Z` |
+| `source_device_id` | string | required | Configured or logical identifier for the biometric device that produced the source record. | `att-dev-dk-01` |
+| `employee_id` | string | required | Employee or device user identifier from the source device. | `10042` |
+| `event_timestamp` | string | required | ISO 8601 timestamp for when the attendance event occurred. | `2026-05-27T08:59:12Z` |
+| `event_type` | string | required | Canonical event type. Supported baseline values are `clock_in`, `clock_out`, and `unknown`. | `clock_in` |
+| `ingested_at` | string | required | ISO 8601 timestamp for when the source record was ingested. | `2026-05-27T09:00:03Z` |
+| `source_record_id` | string | optional | Original source-device record identifier, if the device or extraction layer provides one. | `zk-879221` |
+| `employee_name` | string | optional | Enrichment or display name associated with the employee. | `Ayesha Khan` |
+| `site_id` | string | optional | Logical office or site identifier associated with the source device. | `dk` |
+| `raw_event_type` | string | optional | Original source-device event or status value before canonicalisation. | `Check In` |
+| `metadata` | object | optional | Extension object for implementation-specific fields that should not become top-level contract fields yet. | `{"source_format":"zkteco"}` |
+
+## Minimal Payload
+
+```json
+{
+  "event_id": "att-dev-dk-01-10042-2026-05-27T08:59:12Z",
+  "source_device_id": "att-dev-dk-01",
+  "employee_id": "10042",
+  "event_timestamp": "2026-05-27T08:59:12Z",
+  "event_type": "clock_in",
+  "ingested_at": "2026-05-27T09:00:03Z"
+}
+```
+
+## Full Payload
+
+```json
+{
+  "event_id": "att-dev-dk-01-10042-2026-05-27T08:59:12Z",
+  "source_device_id": "att-dev-dk-01",
+  "employee_id": "10042",
+  "event_timestamp": "2026-05-27T08:59:12Z",
+  "event_type": "clock_in",
+  "ingested_at": "2026-05-27T09:00:03Z",
+  "source_record_id": "zk-879221",
+  "employee_name": "Ayesha Khan",
+  "site_id": "dk",
+  "raw_event_type": "Check In",
+  "metadata": {
+    "source_format": "zkteco",
+    "source_timezone": "Asia/Karachi"
+  }
+}
+```
+
+## Non-Goals
+
+- This document defines the canonical attendance event contract only.
+- Runtime validation and enforcement are future work.
+- Device-specific raw payload formats are outside this document.


### PR DESCRIPTION
<!--
planning_metadata:
  estimated_effort: 0.5h
  priority: High
  milestone_id: 1
  milestone: "1. Documentation & Repo Polish"
-->

## Summary
Document the canonical attendance event schema used by the system.

## Should have
- Add canonical attendance event schema
- Include one JSON example
- Document field meanings

## Nice to have
- Include minimal and full payload examples
- Mark required vs optional fields

## Acceptance criteria
- [x] Canonical schema is documented in README or linked docs
- [x] Field descriptions are clear
- [x] Example payload is consistent with implementation direction
