### PR TITLE
ETLP-20: adds future roadmap and refines repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ current limitations, see [Architecture](docs/architecture.md).
 
 The intended data flow is:
 
-```text
-Extract -> Transform/Canonicalise -> Publish -> Process -> Store/Review
+```mermaid
+flowchart LR
+  Extract --> Canonicalise --> Publish --> Process --> StoreReview[Store / Review]
 ```
 
 For the ordered stage-by-stage pipeline, including current implementation paths and known limitations, see
@@ -50,10 +51,8 @@ For the ordered stage-by-stage pipeline, including current implementation paths 
 
 ## Reliability Mechanisms
 
-The ingestion workflow uses a finite state machine with checkpoint persistence, timeout-aware Pub/Sub waits,
-and retry/sleep paths for missing review metadata. The model is designed to let the compatibility Pi client
-resume from the last checkpointed non-waiting state after interruption without claiming exactly-once delivery
-or transactional recovery.
+The ingestion workflow uses a finite state machine with checkpoint persistence, retry paths, and interruption
+recovery behaviour designed to resume from the last checkpointed non-waiting state.
 
 ![Raspberry Pi client finite state machine](docs/diagrams/pi4-client-fsm.png "Raspberry Pi client finite state machine")
 
@@ -76,16 +75,8 @@ The repository currently contains:
 ## Future Roadmap
 
 Near-term work should stay focused on making the existing ETL system easier to reason about, test, and
-extend:
-
-- Adopt the canonical attendance event schema across transformation and downstream processing.
-- Document architecture and data contracts.
-- Add focused tests around ingestion and function behavior.
-- Isolate the transformation layer.
-- Introduce a device abstraction around biometric attendance extraction.
-- Introduce messaging and storage abstractions around Pub/Sub and Google Sheets boundaries.
-- Isolate reliability and finite state machine behavior for testability.
-- Continue repository and portfolio documentation polish.
+extend. For the post-MVP roadmap, including future PostgreSQL persistence, API layer, and reporting and
+analytics direction, see [Future Work](docs/future-work.md).
 
 ## Contributing
 
@@ -101,4 +92,5 @@ Key repository references:
 - [Data pipeline](docs/data-pipeline.md)
 - [Reliability model](docs/reliability.md)
 - [Canonical attendance event contract](docs/contracts/canonical-attendance-event.md)
+- [Future work](docs/future-work.md)
 - [CI workflow](.github/workflows/ci.yml)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Architecture](architecture.md)
 - [Data pipeline](data-pipeline.md)
 - [Reliability model](reliability.md)
+- [Future work](future-work.md)
 
 ## Contracts
 

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -1,0 +1,64 @@
+# Future Work
+
+This roadmap describes likely post-MVP evolution paths for the attendance ETL system. It is directional, not
+a committed delivery plan. Current implementation focus remains ETL correctness, maintainability, and clear
+repository boundaries.
+
+For current architecture, pipeline sequencing, reliability behavior, and event shape, see
+[Architecture](architecture.md), [Data Pipeline](data-pipeline.md), [Reliability Model](reliability.md), and
+[Canonical Attendance Event](contracts/canonical-attendance-event.md).
+
+## Near-Term
+
+- Adopt the canonical attendance event contract end to end across transformation, publication, backend
+  processing, and persistence boundaries.
+- Isolate the transformation layer so device-specific decoding and canonical event construction are explicit
+  and testable.
+- Add focused ingestion and function tests around current ZKTeco extraction, Pub/Sub message handling, and
+  Google Sheets update behavior.
+- Introduce a small device abstraction around biometric attendance extraction while preserving the existing
+  ZKTeco path.
+- Improve validation and runtime schema checks at publication and backend processing boundaries.
+- Separate reliability and finite state machine behavior from the ingestion client into dedicated modules.
+- Improve dependency isolation for Cloud Function deployment wrappers and shared package code.
+- Improve local development and validation ergonomics without changing production behavior.
+
+## Mid-Term
+
+- Evaluate PostgreSQL as a future persistence backend for attendance events and review state. PostgreSQL is
+  not currently implemented and could either complement or replace parts of the Google Sheets-backed review
+  persistence after the storage contract is better understood.
+- Add a storage abstraction so Google Sheets behavior and any future database-backed persistence can share
+  clearer interfaces and validation expectations.
+- Introduce an API boundary for querying attendance events, review state, and administrative or reporting
+  workflows. This API layer is not currently implemented and should remain high level until concrete caller
+  needs are validated.
+- Extend ingestion through an abstraction that can support additional biometric vendors without forcing a
+  rewrite of canonicalisation, publication, or backend processing.
+- Mature reporting and analytics capabilities around aggregated attendance reporting, historical summaries,
+  operational reporting, and trend analysis using the canonical event model.
+- Replace or complement the Google Sheets review surface where a more structured review workflow proves
+  necessary.
+- Enforce contract and runtime validation consistently across ingestion, publication, function processing, and
+  persistence.
+
+## Long-Term
+
+- Provide historical attendance analytics built from stored canonical events and review outcomes.
+- Add operational dashboards for ingestion health, pending review state, and storage outcomes.
+- Build event replay or recovery tooling for reprocessing attendance events after operational failures.
+- Support richer reporting exports for HR review and audit workflows.
+- Expand multi-site ingestion support when multiple devices or locations become a validated requirement.
+- Define storage partitioning, retention, and archival strategies after the expected data volume and review
+  history requirements are known.
+
+## Non-Goals / Deferred Ideas
+
+- The current roadmap does not redesign the system into a distributed platform or commit to a production
+  migration plan.
+- PostgreSQL, an API layer, and a reporting and analytics layer are future directions, not currently implemented
+  components.
+- Production hardening and architecture evolution should follow validated operational needs, not speculative
+  scale assumptions.
+- Current work should continue to prioritize ETL correctness, deterministic behavior, maintainable module
+  boundaries, and explicit contracts.


### PR DESCRIPTION
<!--
planning_metadata:
  estimated_effort: 0.5h
  priority: Medium
  milestone_id: 1
  milestone: "1. Documentation & Repo Polish"
-->

## Summary
Create a future-work document describing post-MVP evolution paths.

## Should have
- Create docs/future-work.md
- Document future PostgreSQL persistence
- Document API layer direction
- Document analytics backend direction

## Nice to have
- Split into near-term / mid-term / long-term

## Acceptance criteria
- [x] docs/future-work.md exists
- [x] Scope is realistic and aligned with project direction
