### PR TITLE
ETLP-78: adds unified validation runner

### DIFF
--- a/docs/workflows/local-development.md
+++ b/docs/workflows/local-development.md
@@ -20,10 +20,7 @@ source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -e ".[dev]"
 pre-commit install
-python -m ruff check .
-python -m black --check .
-python -m mypy src
-git diff --check
+./scripts/validate.sh
 ```
 
 ## Setup
@@ -77,23 +74,22 @@ rerun the hooks before committing.
 
 ## Local Validation
 
-Run the required validation gates before reporting implementation completion:
+Run the canonical local validation runner before reporting implementation
+completion:
 
 ```sh
-python -m ruff check .
-python -m black --check .
-python -m mypy src
-git diff --check
+./scripts/validate.sh
 ```
 
-If the virtual environment is not activated, run the Python tools through the
-environment interpreter instead:
+The runner executes the mandatory local gates listed in
+`validation-gates.md`. It resolves the repository root before running, uses the
+active virtual environment when one is available, falls back to `.venv`, and
+then falls back to `python3`.
+
+Pre-commit remains useful before individual commits:
 
 ```sh
-.venv/bin/python -m ruff check .
-.venv/bin/python -m black --check .
-.venv/bin/python -m mypy src
-git diff --check
+pre-commit run
 ```
 
 `pytest` is pending repository test-tooling promotion and is not mandatory yet.

--- a/docs/workflows/validation-gates.md
+++ b/docs/workflows/validation-gates.md
@@ -7,19 +7,19 @@ commit creation, or pull request review.
 
 Always run:
 
-    .venv/bin/python -m ruff check .
+    ./scripts/validate.sh
 
-    .venv/bin/python -m black --check .
+The validation runner is the canonical local entry point. It runs, in order:
 
-    .venv/bin/python -m mypy src
+- Ruff lint: `python -m ruff check .`
+- Black format check: `python -m black --check .`
+- MyPy type check: `python -m mypy src`
+- Git whitespace check: `git diff --check`
 
-    git diff --check
+The runner resolves the Python interpreter from the active virtual environment
+when available, then `.venv`, then `python3`.
 
 Pending validation commands:
-
-    ./scripts/validate.sh
-    # Pending: dedicated validation runner
-    # Enable once the repository-level validation runner is implemented.
 
     .venv/bin/python -m pytest -q
     # Pending: ETLP-7
@@ -54,7 +54,8 @@ Install and run the hooks from the project development environment:
 
 The repository CI workflow is `.github/workflows/ci.yml`.
 CI must run on push and pull request events and enforce the mandatory lint,
-format, and type gates listed above.
+format, and type gates listed above. Local validation should use
+`./scripts/validate.sh`.
 
 Test execution remains pending until the pytest command is promoted from the
 pending validation commands.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+  PYTHON="${VIRTUAL_ENV}/bin/python"
+elif [[ -x ".venv/bin/python" ]]; then
+  PYTHON=".venv/bin/python"
+else
+  PYTHON="python3"
+fi
+
+section() {
+  printf '\n==> %s\n' "$1"
+}
+
+section "Ruff lint"
+"$PYTHON" -m ruff check .
+
+section "Black format check"
+"$PYTHON" -m black --check .
+
+section "MyPy type check"
+"$PYTHON" -m mypy src
+
+section "Git whitespace check"
+git diff --check
+
+section "Validation complete"


### PR DESCRIPTION
<!--
planning_metadata:
  estimated_effort: 1h
  priority: High
  milestone_id: 2
  milestone: "Repository Structure Modernisation"
-->

## Summary
Add a single local validation entry point that runs the repository’s mandatory quality gates consistently.

## Should have
- Add `scripts/validate.sh`
- Run Ruff lint
- Run Black format check
- Run MyPy
- Run `git diff --check`
- Keep pytest pending unless test execution is fully configured
- Document the validation runner in local development docs

## Nice to have
- Make the script fail fast
- Print clear section headers
- Use the active virtual environment when available

## Acceptance criteria
- [x] `scripts/validate.sh` exists and is executable
- [x] The script runs all currently mandatory validation gates
- [x] The script output is clear enough for contributors and AI agents
- [x] Local development and validation-gates documentation reference the script