### PR TITLE
ETLP-77: adds automated version management

### DIFF
--- a/docs/workflows/local-development.md
+++ b/docs/workflows/local-development.md
@@ -106,6 +106,41 @@ python -m compileall src
 This compile check is optional and does not replace the required validation
 gates.
 
+## Version Management
+
+The canonical project version is `project.version` in `pyproject.toml`.
+Version updates are managed manually with Bump My Version through the
+configuration in `pyproject.toml`.
+
+After installing the development tooling, bump the version with one of:
+
+```sh
+.venv/bin/bump-my-version bump patch
+.venv/bin/bump-my-version bump minor
+.venv/bin/bump-my-version bump major
+```
+
+Review the resulting diff before committing, then run:
+
+```sh
+./scripts/validate.sh
+```
+
+To inspect the configured bump without applying it, run:
+
+```sh
+.venv/bin/bump-my-version bump --dry-run --allow-dirty -vv patch
+```
+
+The verbose dry run prints the planned version change and file update while
+leaving the working tree unchanged. Version consistency should be checked by
+reviewing the `pyproject.toml` diff and by running the canonical validation
+runner.
+
+This setup is local/manual version management only. Future release automation
+may reuse the same configuration, but no release workflow, automatic tagging,
+publishing, or push behavior is configured.
+
 ## Common Pitfalls
 
 - Forgetting to activate `.venv` and accidentally using global tools.
@@ -114,3 +149,4 @@ gates.
 - Treating `pytest` as mandatory before project test tooling is configured.
 - Assuming every Cloud Function dependency is a root package dependency; some
   function dependencies remain per-function.
+- Running a version bump without reviewing the diff before commit creation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attendance-etl"
-version = "0.1.0"
+version = "1.0.0"
 description = "Attendance ETL package"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -17,6 +17,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "black>=24.10.0",
+    "bump-my-version>=0.28.0",
     "mypy>=1.13.0,<1.15",
     "pre-commit>=4.0.0,<5",
     "ruff>=0.8.0",
@@ -36,6 +37,23 @@ select = ["E4", "E7", "E9", "F"]
 [tool.black]
 line-length = 120
 target-version = ["py38"]
+
+[tool.bumpversion]
+current_version = "1.0.0"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = false
+tag = false
+sign_tags = false
+commit = false
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
 
 [tool.mypy]
 python_version = "3.8"


### PR DESCRIPTION
<!--
planning_metadata:
  estimated_effort: 1h
  priority: Medium
  milestone_id: 2
  milestone: "Repository Structure Modernisation"
-->

## Summary
Add automated version management so project version updates are explicit, repeatable, and centrally controlled.

## Should have
- Add `bump-my-version` configuration
- Define a single canonical project version source
- Document patch/minor/major version bump commands
- Ensure version updates are reproducible

## Nice to have
- Add validation guidance for checking version consistency
- Prepare future compatibility with release automation

## Acceptance criteria
- [x] Project version is centrally managed
- [x] Version bump commands are documented
- [x] Version bump behaviour is deterministic
- [x] No release automation is introduced prematurely