### PR TITLE
ETLP-22: centralises ingestion runtime configuration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,8 +84,10 @@ The Raspberry Pi ingestion client is split into focused package modules:
 - `attendance_etl.device.zkteco` owns ZKTeco connection lifecycle, device reads, and attendance clearing.
 - `attendance_etl.transform.zkteco_records` owns current ZKTeco user mapping, filtering, and transitional
   record decoding.
-- `attendance_etl.messaging.pubsub` owns Pub/Sub constants, publication, subscriptions, targeted pulls, ACKs,
-  and message decoding.
+- `attendance_etl.config` owns shared runtime configuration constants such as Pub/Sub names, local runtime
+  files, polling intervals, and device connection defaults.
+- `attendance_etl.messaging.pubsub` owns Pub/Sub publication, subscriptions, targeted pulls, ACKs, and message
+  decoding.
 - `attendance_etl.storage.snapshot` and `attendance_etl.storage.review_period` own the existing JSON files.
 - `attendance_etl.pi4.state`, `attendance_etl.pi4.workflow`, and `attendance_etl.pi4.runtime` own Pi state,
   finite-state-machine behavior, and runtime composition.

--- a/src/attendance_etl/config.py
+++ b/src/attendance_etl/config.py
@@ -1,0 +1,35 @@
+"""Central configuration constants for the attendance ETL runtime."""
+
+from datetime import timedelta
+
+# Google Cloud project that owns the current Pub/Sub topics.
+PROJECT_ID = "attend1"
+
+# Pub/Sub topics used by the ingestion workflow and Cloud Function responses.
+GET_REVIEW_PERIOD_TOPIC = "get_review_period"
+NEW_REVIEW_PERIOD_TOPIC = "new_review_period"
+CREATE_REVIEW_SHEET_TOPIC = "create_review_sheet"
+NEW_REVIEW_SHEET_TOPIC = "new_review_sheet"
+STORE_ATTEND_RECORDS_TOPIC = "store_attend_records"
+LAST_STORED_TIMESTAMP_TOPIC = "last_stored_timestamp"
+
+# Pub/Sub subscription naming and pull behavior.
+SUBSCRIPTION_NAME = "sub_{}_{}"
+ACK_DEADLINE = 10
+SUBSCRIPTION_TTL = 7776000
+MAX_LIMIT = 1
+PULL_MSG_TIMEOUT = 30.0
+
+# Local files used by the Raspberry Pi runtime.
+SNAPSHOT_FILE = "snapshot.json"
+REVIEW_PERIOD_JSON = "review_period.json"
+BIOMETRIC_DEVICE_CONFIG_FILE = "biometric_device_config.json"
+
+# Runtime sleep intervals for normal polling and missing-review-period recovery.
+POLLING_DELAY = timedelta(minutes=15)
+DEEP_SLEEP_DURATION = timedelta(hours=1)
+
+# ZKTeco device connection options. The ommit_ping name follows the pyzk API.
+ZKTECO_TIMEOUT = 10
+ZKTECO_FORCE_UDP = False
+ZKTECO_OMMIT_PING = False

--- a/src/attendance_etl/device/zkteco.py
+++ b/src/attendance_etl/device/zkteco.py
@@ -1,7 +1,6 @@
 from zk import ZK
 
-# constant(s) for communicating with the zkteco biometric device
-DEVICE_TIME_OUT = 10
+from attendance_etl import config
 
 
 class ZKTecoDevice:
@@ -25,9 +24,9 @@ def clear_records_from_device(device_ip, comm_port):
     zk = ZK(
         device_ip,
         port=comm_port,
-        timeout=DEVICE_TIME_OUT,
-        force_udp=False,
-        ommit_ping=False,
+        timeout=config.ZKTECO_TIMEOUT,
+        force_udp=config.ZKTECO_FORCE_UDP,
+        ommit_ping=config.ZKTECO_OMMIT_PING,
     )
     try:
         print("Connecting to device ...")
@@ -57,9 +56,9 @@ def pull_records_from_device(device_ip, comm_port):
     zk = ZK(
         device_ip,
         port=comm_port,
-        timeout=DEVICE_TIME_OUT,
-        force_udp=False,
-        ommit_ping=False,
+        timeout=config.ZKTECO_TIMEOUT,
+        force_udp=config.ZKTECO_FORCE_UDP,
+        ommit_ping=config.ZKTECO_OMMIT_PING,
     )
     try:
         users = []

--- a/src/attendance_etl/messaging/pubsub.py
+++ b/src/attendance_etl/messaging/pubsub.py
@@ -1,28 +1,15 @@
 import json
 
-# constants defined for GCP pub/sub message exchange
-PROJECT_ID = "attend1"
-GET_REVIEW_PERIOD_TOPIC = "get_review_period"
-NEW_REVIEW_PERIOD_TOPIC = "new_review_period"
-CREATE_REVIEW_SHEET_TOPIC = "create_review_sheet"
-NEW_REVIEW_SHEET_TOPIC = "new_review_sheet"
-STORE_ATTEND_RECORDS_TOPIC = "store_attend_records"
-LAST_STORED_TIMESTAMP_TOPIC = "last_stored_timestamp"
-
-SUBSCRIPTION_NAME = "sub_{}_{}"
-ACK_DEADLINE = 10  # lease time (in seconds) to acknowledge the receipt of a message
-SUBSCRIPTION_TTL = 7776000  # 90 days (in seconds)
-MAX_LIMIT = 1
-PULL_MSG_TIMEOUT = 30.0  # How long the subscriber should listen for messages in seconds
+from attendance_etl import config
 
 
 class PubSubMessenger:
-    def __init__(self, device_identifier, project_id=PROJECT_ID):
+    def __init__(self, device_identifier, project_id=config.PROJECT_ID):
         self.device_identifier = device_identifier
         self.project_id = project_id
 
     def subscription_name(self, topic_name):
-        return SUBSCRIPTION_NAME.format(topic_name, self.device_identifier)
+        return config.SUBSCRIPTION_NAME.format(topic_name, self.device_identifier)
 
     def publish_message_to_topic(self, topic_name, data):
         publish_message_to_topic(self.project_id, topic_name, data)
@@ -56,7 +43,7 @@ def publish_message_to_topic(project_id, topic_name, data):
     print(log_msg.format(message_id, payload, topic_name))
 
 
-def subscription_exists(topic_name, subscription_name, project_id=PROJECT_ID):
+def subscription_exists(topic_name, subscription_name, project_id=config.PROJECT_ID):
     """
     checks whether the subscription exists against the input topic or not
     """
@@ -75,7 +62,7 @@ def subscription_exists(topic_name, subscription_name, project_id=PROJECT_ID):
     return retVal
 
 
-def create_subscription(topic_name, subscription_name, project_id=PROJECT_ID):
+def create_subscription(topic_name, subscription_name, project_id=config.PROJECT_ID):
     """
     creates a gcp pub/sub subscription for the input topic name if it
     does not exist
@@ -89,12 +76,12 @@ def create_subscription(topic_name, subscription_name, project_id=PROJECT_ID):
         subscriber = pubsub_v1.SubscriberClient()
         sub_path = subscriber.subscription_path(project_id, subscription_name)
         topic_path = subscriber.topic_path(project_id, topic_name)
-        ttl_duration = duration_pb2.Duration(seconds=SUBSCRIPTION_TTL)
+        ttl_duration = duration_pb2.Duration(seconds=config.SUBSCRIPTION_TTL)
         expiration_policy = pubsub_v1.types.ExpirationPolicy(ttl=ttl_duration)
         subscriber.create_subscription(
             name=sub_path,
             topic=topic_path,
-            ack_deadline_seconds=ACK_DEADLINE,
+            ack_deadline_seconds=config.ACK_DEADLINE,
             expiration_policy=expiration_policy,
         )
 
@@ -113,7 +100,7 @@ def is_directed_to_device(pubsub_message, device_identifier):
     return for_me
 
 
-def sync_pull_message(subscription_name, device_identifier, project_id=PROJECT_ID):
+def sync_pull_message(subscription_name, device_identifier, project_id=config.PROJECT_ID):
     """
     synchronously pulls pub/sub messages from the input subscription_name
     until a message targeted for this Raspberry Pi4 device is received
@@ -129,7 +116,11 @@ def sync_pull_message(subscription_name, device_identifier, project_id=PROJECT_I
     while not msg_receipt:
         log_msg = "waiting for message from {} subscription..."
         print(log_msg.format(subscription_name))
-        response = subscriber.pull(subscription_path, max_messages=MAX_LIMIT, timeout=PULL_MSG_TIMEOUT)
+        response = subscriber.pull(
+            subscription_path,
+            max_messages=config.MAX_LIMIT,
+            timeout=config.PULL_MSG_TIMEOUT,
+        )
 
         ack_ids = []
         for received_message in response.received_messages:

--- a/src/attendance_etl/pi4/runtime.py
+++ b/src/attendance_etl/pi4/runtime.py
@@ -1,5 +1,6 @@
 import json
 
+from attendance_etl import config
 from attendance_etl.device.zkteco import ZKTecoDevice
 from attendance_etl.messaging.pubsub import PubSubMessenger
 from attendance_etl.pi4.state import Pi4RuntimeState
@@ -7,11 +8,8 @@ from attendance_etl.pi4.workflow import Pi4Workflow
 from attendance_etl.storage.review_period import ReviewPeriodStore
 from attendance_etl.storage.snapshot import SnapshotStore
 
-# constants defined for on-disk files
-BIOMETRIC_DEVICE_CONFIG_FILE = "biometric_device_config.json"
 
-
-def setup_device_info(path=BIOMETRIC_DEVICE_CONFIG_FILE):
+def setup_device_info(path=config.BIOMETRIC_DEVICE_CONFIG_FILE):
     """
     loads the configuration details of the attendance devices
     from the configuration file

--- a/src/attendance_etl/pi4/workflow.py
+++ b/src/attendance_etl/pi4/workflow.py
@@ -2,14 +2,7 @@ import time
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, cast
 
-from attendance_etl.messaging.pubsub import (
-    CREATE_REVIEW_SHEET_TOPIC,
-    GET_REVIEW_PERIOD_TOPIC,
-    LAST_STORED_TIMESTAMP_TOPIC,
-    NEW_REVIEW_PERIOD_TOPIC,
-    NEW_REVIEW_SHEET_TOPIC,
-    STORE_ATTEND_RECORDS_TOPIC,
-)
+from attendance_etl import config
 from attendance_etl.pi4.state import (
     AWAIT_LAST_STORED_TIMESTAMP,
     AWAIT_REVIEW_PERIOD,
@@ -24,10 +17,6 @@ from attendance_etl.pi4.state import (
     WAITING_STATES,
 )
 from attendance_etl.transform.zkteco_records import convert_to_map, decode_zk_format, filter_records
-
-# constants defined for delay/sleep intervals
-POLLING_DELAY = timedelta(minutes=15)
-DEEP_SLEEP_DURATION = timedelta(hours=1)
 
 
 class Pi4Workflow:
@@ -109,11 +98,11 @@ class Pi4Workflow:
             # consider Sunday as the last day of this review period
             last_day += timedelta(days=2)
 
-        wait_duration = POLLING_DELAY
+        wait_duration = config.POLLING_DELAY
         if now.date() == last_day.date():
             # today's the last day of this review period
             delta_midnight = last_day + timedelta(days=1) - now
-            wait_duration = min(POLLING_DELAY, delta_midnight)
+            wait_duration = min(config.POLLING_DELAY, delta_midnight)
 
         return wait_duration
 
@@ -150,7 +139,7 @@ class Pi4Workflow:
         # at this point the REVIEW_PERIOD_INFO object contains the details of
         # the attendance review period that just ended i.e. the previous review
         # period
-        self.messenger.publish_message_to_topic(GET_REVIEW_PERIOD_TOPIC, self.state.review_period_info)
+        self.messenger.publish_message_to_topic(config.GET_REVIEW_PERIOD_TOPIC, self.state.review_period_info)
 
         self.transition_state(AWAIT_REVIEW_PERIOD)
 
@@ -158,8 +147,8 @@ class Pi4Workflow:
         """
         executes the logic for handling the AWAIT_REVIEW_PERIOD state
         """
-        subscription_name = self.messenger.subscription_name(NEW_REVIEW_PERIOD_TOPIC)
-        self.messenger.create_subscription(NEW_REVIEW_PERIOD_TOPIC, subscription_name)
+        subscription_name = self.messenger.subscription_name(config.NEW_REVIEW_PERIOD_TOPIC)
+        self.messenger.create_subscription(config.NEW_REVIEW_PERIOD_TOPIC, subscription_name)
         new_review_period = self.messenger.sync_pull_message(subscription_name)
 
         next_state = None
@@ -201,7 +190,7 @@ class Pi4Workflow:
         executes the logic for handling the NO_REVIEW_PERIOD state
         """
         # enter a deep sleep, re-check for the next review period on wake up!
-        time.sleep(DEEP_SLEEP_DURATION.total_seconds())
+        time.sleep(config.DEEP_SLEEP_DURATION.total_seconds())
         self.transition_state(FETCH_REVIEW_PERIOD)
 
     def handler_request_review_sheet(self):
@@ -210,7 +199,7 @@ class Pi4Workflow:
         """
         # in this state the REVIEW_PERIOD_INFO object contains the information of
         # the new attendance review period that is about to begin
-        self.messenger.publish_message_to_topic(CREATE_REVIEW_SHEET_TOPIC, self.state.review_period_info)
+        self.messenger.publish_message_to_topic(config.CREATE_REVIEW_SHEET_TOPIC, self.state.review_period_info)
 
         self.transition_state(AWAIT_REVIEW_SHEET)
 
@@ -218,8 +207,8 @@ class Pi4Workflow:
         """
         executes the logic for handling the AWAIT_REVIEW_SHEET state
         """
-        subscription_name = self.messenger.subscription_name(NEW_REVIEW_SHEET_TOPIC)
-        self.messenger.create_subscription(NEW_REVIEW_SHEET_TOPIC, subscription_name)
+        subscription_name = self.messenger.subscription_name(config.NEW_REVIEW_SHEET_TOPIC)
+        self.messenger.create_subscription(config.NEW_REVIEW_SHEET_TOPIC, subscription_name)
         new_review_sheet = self.messenger.sync_pull_message(subscription_name)
 
         # store the review sheet id of the Attendance Review sheet for the new
@@ -258,15 +247,15 @@ class Pi4Workflow:
             request_params["device_id"] = self.device_info()["identifier"]
             request_params["start_date"] = review_period_info["start_date"]
             request_params["records"] = new_records
-            self.messenger.publish_message_to_topic(STORE_ATTEND_RECORDS_TOPIC, request_params)
+            self.messenger.publish_message_to_topic(config.STORE_ATTEND_RECORDS_TOPIC, request_params)
             self.transition_state(AWAIT_LAST_STORED_TIMESTAMP)
 
     def handler_await_last_stored_timestamp(self):
         """
         executes the logic for handling the AWAIT_LAST_STORED_TIMESTAMP state
         """
-        subscription_name = self.messenger.subscription_name(LAST_STORED_TIMESTAMP_TOPIC)
-        self.messenger.create_subscription(LAST_STORED_TIMESTAMP_TOPIC, subscription_name)
+        subscription_name = self.messenger.subscription_name(config.LAST_STORED_TIMESTAMP_TOPIC)
+        self.messenger.create_subscription(config.LAST_STORED_TIMESTAMP_TOPIC, subscription_name)
         last_stored_record = self.messenger.sync_pull_message(subscription_name)
 
         # update the timestamp of the most recent attendance record saved

--- a/src/attendance_etl/storage/review_period.py
+++ b/src/attendance_etl/storage/review_period.py
@@ -1,11 +1,10 @@
 import json
 
-# constants defined for on-disk files
-REVIEW_PERIOD_JSON = "review_period.json"
+from attendance_etl import config
 
 
 class ReviewPeriodStore:
-    def __init__(self, path=REVIEW_PERIOD_JSON):
+    def __init__(self, path=config.REVIEW_PERIOD_JSON):
         self.path = path
 
     def load(self):
@@ -15,7 +14,7 @@ class ReviewPeriodStore:
         save_review_period(review_period_info, self.path)
 
 
-def load_review_period(path=REVIEW_PERIOD_JSON):
+def load_review_period(path=config.REVIEW_PERIOD_JSON):
     """
     loads the review period information from the json file
     """
@@ -23,7 +22,7 @@ def load_review_period(path=REVIEW_PERIOD_JSON):
         return json.load(json_file)
 
 
-def save_review_period(review_period_info, path=REVIEW_PERIOD_JSON):
+def save_review_period(review_period_info, path=config.REVIEW_PERIOD_JSON):
     """
     saves the review period json to the disk
     """

--- a/src/attendance_etl/storage/snapshot.py
+++ b/src/attendance_etl/storage/snapshot.py
@@ -1,11 +1,10 @@
 import json
 
-# constants defined for on-disk files
-SNAPSHOT_FILE = "snapshot.json"
+from attendance_etl import config
 
 
 class SnapshotStore:
-    def __init__(self, path=SNAPSHOT_FILE):
+    def __init__(self, path=config.SNAPSHOT_FILE):
         self.path = path
 
     def load(self):
@@ -21,7 +20,7 @@ class SnapshotStore:
         )
 
 
-def load_snapshot(path=SNAPSHOT_FILE):
+def load_snapshot(path=config.SNAPSHOT_FILE):
     """
     loads the snapshot captured during checkpointing to resume operation
     without losing state information in case of a (device) shutdown
@@ -30,7 +29,13 @@ def load_snapshot(path=SNAPSHOT_FILE):
         return json.load(json_file)
 
 
-def save_snapshot(pi4_state, system_flags, review_sheet_id, last_stored_timestamp, path=SNAPSHOT_FILE):
+def save_snapshot(
+    pi4_state,
+    system_flags,
+    review_sheet_id,
+    last_stored_timestamp,
+    path=config.SNAPSHOT_FILE,
+):
     """
     saves the runtime snapshot to disk using the legacy JSON shape.
     """

--- a/tests/unit/ingestion/test_config.py
+++ b/tests/unit/ingestion/test_config.py
@@ -1,0 +1,151 @@
+import unittest
+from datetime import timedelta
+
+from attendance_etl import config
+from attendance_etl.device import zkteco
+from attendance_etl.messaging.pubsub import PubSubMessenger
+from attendance_etl.pi4 import runtime
+from attendance_etl.pi4.state import FETCH_REVIEW_PERIOD, Pi4RuntimeState
+from attendance_etl.pi4.workflow import Pi4Workflow
+from attendance_etl.storage.review_period import ReviewPeriodStore
+from attendance_etl.storage.snapshot import SnapshotStore
+
+
+class SnapshotSpy:
+    def save(self, pi4_state, system_flags, review_sheet_id, last_stored_timestamp):
+        pass
+
+
+class ReviewPeriodStoreSpy:
+    def save(self, review_period_info):
+        pass
+
+
+class DeviceStub:
+    pass
+
+
+class MessengerSpy:
+    def __init__(self):
+        self.published = []
+
+    def publish_message_to_topic(self, topic_name, data):
+        self.published.append((topic_name, data))
+
+
+class FakeConnection:
+    def disable_device(self):
+        pass
+
+    def enable_device(self):
+        pass
+
+    def get_firmware_version(self):
+        return "fake"
+
+    def get_users(self):
+        return []
+
+    def get_attendance(self):
+        return []
+
+    def clear_attendance(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+
+class FakeZK:
+    instances = []
+
+    def __init__(self, device_ip, port, timeout, force_udp, ommit_ping):
+        self.device_ip = device_ip
+        self.port = port
+        self.timeout = timeout
+        self.force_udp = force_udp
+        self.ommit_ping = ommit_ping
+        FakeZK.instances.append(self)
+
+    def connect(self):
+        return FakeConnection()
+
+
+class ConfigTests(unittest.TestCase):
+    def test_config_constants_preserve_existing_default_values(self):
+        self.assertEqual(config.PROJECT_ID, "attend1")
+        self.assertEqual(config.GET_REVIEW_PERIOD_TOPIC, "get_review_period")
+        self.assertEqual(config.NEW_REVIEW_PERIOD_TOPIC, "new_review_period")
+        self.assertEqual(config.CREATE_REVIEW_SHEET_TOPIC, "create_review_sheet")
+        self.assertEqual(config.NEW_REVIEW_SHEET_TOPIC, "new_review_sheet")
+        self.assertEqual(config.STORE_ATTEND_RECORDS_TOPIC, "store_attend_records")
+        self.assertEqual(config.LAST_STORED_TIMESTAMP_TOPIC, "last_stored_timestamp")
+        self.assertEqual(config.SUBSCRIPTION_NAME, "sub_{}_{}")
+        self.assertEqual(config.ACK_DEADLINE, 10)
+        self.assertEqual(config.SUBSCRIPTION_TTL, 7776000)
+        self.assertEqual(config.MAX_LIMIT, 1)
+        self.assertEqual(config.PULL_MSG_TIMEOUT, 30.0)
+        self.assertEqual(config.SNAPSHOT_FILE, "snapshot.json")
+        self.assertEqual(config.REVIEW_PERIOD_JSON, "review_period.json")
+        self.assertEqual(config.BIOMETRIC_DEVICE_CONFIG_FILE, "biometric_device_config.json")
+        self.assertEqual(config.POLLING_DELAY, timedelta(minutes=15))
+        self.assertEqual(config.DEEP_SLEEP_DURATION, timedelta(hours=1))
+        self.assertEqual(config.ZKTECO_TIMEOUT, 10)
+        self.assertIs(config.ZKTECO_FORCE_UDP, False)
+        self.assertIs(config.ZKTECO_OMMIT_PING, False)
+
+    def test_runtime_components_use_config_defaults(self):
+        messenger = PubSubMessenger("att-dev-dk-01")
+
+        self.assertEqual(messenger.project_id, config.PROJECT_ID)
+        self.assertEqual(
+            messenger.subscription_name(config.NEW_REVIEW_PERIOD_TOPIC),
+            "sub_new_review_period_att-dev-dk-01",
+        )
+        self.assertEqual(SnapshotStore().path, config.SNAPSHOT_FILE)
+        self.assertEqual(ReviewPeriodStore().path, config.REVIEW_PERIOD_JSON)
+        self.assertEqual(runtime.setup_device_info.__defaults__, (config.BIOMETRIC_DEVICE_CONFIG_FILE,))
+
+    def test_workflow_publishes_to_configured_topics(self):
+        state = Pi4RuntimeState(pi4_state=FETCH_REVIEW_PERIOD)
+        state.review_period_info = {"month": "May"}
+        messenger = MessengerSpy()
+        workflow = Pi4Workflow(
+            state,
+            DeviceStub(),
+            messenger,
+            SnapshotSpy(),
+            ReviewPeriodStoreSpy(),
+        )
+
+        workflow.handler_fetch_review_period()
+        workflow.handler_request_review_sheet()
+
+        self.assertEqual(
+            messenger.published,
+            [
+                (config.GET_REVIEW_PERIOD_TOPIC, {"month": "May"}),
+                (config.CREATE_REVIEW_SHEET_TOPIC, {"month": "May"}),
+            ],
+        )
+
+    def test_zkteco_connection_uses_configured_defaults(self):
+        original_zk = zkteco.ZK
+        FakeZK.instances = []
+        zkteco.ZK = FakeZK
+        try:
+            zkteco.pull_records_from_device("192.0.2.10", 4370)
+        finally:
+            zkteco.ZK = original_zk
+
+        self.assertEqual(len(FakeZK.instances), 1)
+        instance = FakeZK.instances[0]
+        self.assertEqual(instance.device_ip, "192.0.2.10")
+        self.assertEqual(instance.port, 4370)
+        self.assertEqual(instance.timeout, config.ZKTECO_TIMEOUT)
+        self.assertEqual(instance.force_udp, config.ZKTECO_FORCE_UDP)
+        self.assertEqual(instance.ommit_ping, config.ZKTECO_OMMIT_PING)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
planning_metadata:
  estimated_effort: 1h
  priority: Highest
  milestone_id: 2
  milestone: "2. Repository Structure Modernisation"
-->

## Summary
Centralise configuration into a dedicated config module.

## Should have
- Move topic names, file paths, and project IDs into config.py

## Nice to have
- Group related constants clearly
- Add short comments explaining external/runtime values

## Should not Have 
- Support environment-variable overrides

## Acceptance criteria
- [x] Hardcoded config values are removed from business logic
- [x] Config module is easy to extend
