### PR TITLE
ETLP-24: Introduces core domain data-models

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,23 @@ When introducing significant architectural changes:
 2. Review any associated design proposals for implementation intent.
 3. Update architecture documentation to reflect the final system state.
 
+## Engineering Principles
+
+The following principles guide architectural evolution, design decisions,
+and implementation work throughout the project.
+
+### Requirement-Driven Architecture
+
+Do not introduce new architectural abstractions unless:
+
+1. They already exist in the codebase.
+2. They are explicitly required by a ticket or specification.
+3. They are explicitly proposed and approved during design review.
+
+Architectural evolution should be driven by requirements rather than by architectural patterns or perceived symmetry.
+
+The project prefers extending existing abstractions over introducing speculative layers, managers, repositories, registries, adapters, factories, stores, or other constructs without a demonstrated need.
+
 ## Architecture
 
 - [Architecture](architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,8 @@ The Raspberry Pi ingestion client is split into focused package modules:
 - `attendance_etl.device.zkteco` owns ZKTeco connection lifecycle, device reads, and attendance clearing.
 - `attendance_etl.transform.zkteco_records` owns current ZKTeco user mapping, filtering, and transitional
   record decoding.
+- `attendance_etl.models` owns lightweight dataclass representations for core domain contracts such as
+  attendance events, employees, review periods, and persisted runtime state.
 - `attendance_etl.config` owns shared runtime configuration constants such as Pub/Sub names, local runtime
   files, polling intervals, and device connection defaults.
 - `attendance_etl.messaging.pubsub` owns Pub/Sub publication, subscriptions, targeted pulls, ACKs, and message

--- a/docs/contracts/canonical-attendance-event.md
+++ b/docs/contracts/canonical-attendance-event.md
@@ -7,6 +7,10 @@ canonicalisation, and is intended for downstream publication, processing, and pe
 This contract describes the target canonical payload shape. Current device-specific decoding and publishing
 may still emit transitional fields until transformation work adopts this contract end to end.
 
+`attendance_etl.models.AttendanceEvent` is the Python dataclass representation of this contract for internal
+code. Its conversion helpers are available for model/dictionary conversion, but current runtime publishing may
+continue to use transitional dictionaries until canonical adoption is completed separately.
+
 For pipeline stage sequencing, see [Data Pipeline](../data-pipeline.md). For runtime adoption limits, see
 [Architecture](../architecture.md).
 

--- a/docs/decisions/0001-repo-modernisation-design-decisions.md
+++ b/docs/decisions/0001-repo-modernisation-design-decisions.md
@@ -72,7 +72,7 @@ Preferred:
 - MessagingClient
 - RecordTransformer
 - RuntimeState
-- ReviewPeriodStore
+- ReviewPeriod
 - Pi4Workflow
 - Pi4Runtime
 - IngestionClient
@@ -122,12 +122,9 @@ Within ETLP-23 and earlier milestones, RuntimeState refers to the responsibility
 
 ETLP-24 is expected to introduce a dedicated RuntimeState domain model.
 
-Possible future direction:
+RuntimeState is the domain model for persisted ingestion runtime state.
 
-- RuntimeState (domain model)
-- RuntimeStateStore (persistence mechanism)
-
-This preserves a clear separation between state representation and state persistence.
+Persistence remains the responsibility of the existing snapshot persistence code. No additional persistence abstraction is introduced by this decision.
 
 ---
 

--- a/docs/decisions/0002-model-adoption-principles.md
+++ b/docs/decisions/0002-model-adoption-principles.md
@@ -1,0 +1,138 @@
+# Domain Model Adoption Principles
+
+## Context
+
+ETLP-24 introduced the following domain models:
+
+- `AttendanceEvent`
+- `Employee`
+- `ReviewPeriod`
+- `RuntimeState`
+
+The initial implementation created model classes but did not fully adopt them as internal contracts. Existing dictionaries and raw field collections remained the primary mechanism for exchanging data between modules.
+
+This increased complexity without significantly improving the architecture.
+
+## Decision
+
+Domain models shall become the primary internal contracts between modules.
+
+Models are not introduced merely to wrap existing dictionaries.
+
+A model migration is considered complete only when internal module boundaries exchange model instances rather than dictionaries.
+
+## Internal Boundary Rule
+
+Dictionaries shall exist only at:
+
+- serialization boundaries
+- deserialization boundaries
+- persistence boundaries
+- external integration boundaries
+
+Internal module boundaries shall exchange domain models.
+
+## AttendanceEvent
+
+AttendanceEvent is the canonical internal representation of an attendance event.
+
+The ingestion workflow shall operate on AttendanceEvent objects rather than attendance dictionaries.
+
+Device-specific transformations shall convert proprietary attendance records into AttendanceEvent objects as early as possible.
+
+Future device integrations shall integrate through AttendanceEvent rather than introducing new workflow-specific record formats.
+
+## Employee
+
+Employee is the canonical internal representation of a device user.
+
+Employee collections shall store Employee objects rather than names or ad-hoc dictionaries.
+
+Preferred representation:
+
+    Dict[user_id, Employee]
+
+Employee instances shall be reused throughout the ingestion pipeline.
+
+## RuntimeState
+
+RuntimeState is the canonical representation of persisted ingestion state.
+
+Snapshot persistence shall operate on RuntimeState objects.
+
+RuntimeState owns serialization and deserialization.
+
+Snapshot persistence components own file I/O.
+
+## ReviewPeriod
+
+ReviewPeriod is the canonical representation of review period information.
+
+Review-period persistence shall operate on ReviewPeriod objects.
+
+ReviewPeriod owns serialization and deserialization.
+
+Persistence helpers own file I/O.
+
+## Serialization Interfaces
+
+Domain models shall implement:
+
+- `ISerializable`
+- `IDeserializable`
+
+`ISerializable`:
+
+    to_dict() -> Dict[str, Any]
+
+`IDeserializable`:
+
+    from_dict(payload: Dict[str, Any])
+
+The exact serialized shape depends on the model's declared contract.
+
+## Architectural Principle
+
+
+Creating a model without replacing the dictionary-based internal contract is not considered successful model adoption.
+
+## Scope Boundaries
+
+### Context
+
+During ETLP-24 review, it became clear that some model-adoption work overlapped with future roadmap items.
+
+### Decision
+
+ETLP-24 owns:
+
+- `AttendanceEvent` definition
+- `Employee` adoption
+- `ReviewPeriod` adoption
+- `RuntimeState` adoption
+- `ISerializable`
+- `IDeserializable`
+
+ETLP-24 does not own:
+
+- device abstraction
+- canonical transformation
+- messaging abstraction
+
+### Deferred Roadmap Items
+
+Device abstraction remains owned by:
+
+    Milestone 3 — Device Layer Abstraction
+
+Canonical attendance-event adoption remains owned by:
+
+    Milestone 4 — Transformation Layer
+
+Messaging abstraction remains owned by:
+
+    Milestone 5 — Messaging Abstraction
+
+### Consequences
+
+Model adoption may prepare future roadmap work but must not consume the scope of those milestones prematurely.

--- a/docs/proposals/ingestion-modularisation.md
+++ b/docs/proposals/ingestion-modularisation.md
@@ -4,6 +4,20 @@
 
 Refactor the current monolithic ingestion client into focused modules while preserving runtime behavior, Pub/Sub payloads/topics, snapshot semantics, timeout/retry behavior, and the `src/pi4/pi4_client.py` compatibility entry point. Do not adopt the canonical attendance event contract in ETLP-21; keep current transitional record dictionaries.
 
+## Status
+
+Implemented with later corrections.
+
+This proposal records the original ETLP-21 implementation plan. Some proposed abstractions were later rejected or superseded by ADR-0001 and ADR-0002.
+
+## Superseded Planning Notes
+
+The following names appeared in the original ETLP-21 proposal but are no longer accepted implementation targets:
+
+- `AttendanceDevice`: deferred to Milestone 3 — Device Layer Abstraction.
+- `SnapshotStore`: rejected during ETLP-24; use `load_snapshot()` / `save_snapshot(RuntimeState)`.
+- `ReviewPeriodStore`: rejected during ETLP-24; use `load_review_period()` / `save_review_period(ReviewPeriod)`.
+
 ## Current Responsibility Map
 
 | Area | Current Owner | Current Responsibility |
@@ -22,7 +36,7 @@ Refactor the current monolithic ingestion client into focused modules while pres
 attendance_etl/
 ├── device/
 │   ├── __init__.py
-│   ├── interfaces.py        # AttendanceDevice protocol only
+│   ├── interfaces.py        # Original proposal; device abstraction deferred to Milestone 3
 │   └── zkteco.py            # ZKTecoDevice and device timeout
 ├── transform/
 │   ├── __init__.py
@@ -32,8 +46,8 @@ attendance_etl/
 │   └── pubsub.py            # Pub/Sub constants and PubSubMessenger
 ├── storage/
 │   ├── __init__.py
-│   ├── snapshot.py          # SnapshotStore
-│   └── review_period.py     # ReviewPeriodStore
+│   ├── snapshot.py          # Function-based RuntimeState persistence
+│   └── review_period.py     # Function-based ReviewPeriod persistence
 ├── pi4/
 │   ├── __init__.py
 │   ├── runtime.py           # PiRuntime composition/bootstrap/run loop
@@ -47,11 +61,11 @@ attendance_etl/
 
 | Symbol | Module | Responsibility |
 | --- | --- | --- |
-| `AttendanceDevice` | `device.interfaces` | Python 3.8-compatible `Protocol` with `pull_records()` and `clear_records()`; no vendor registry |
+| `AttendanceDevice` | `device.interfaces` | Original proposal; later deferred to Milestone 3 — Device Layer Abstraction |
 | `ZKTecoDevice` | `device.zkteco` | Owns ZKTeco connection lifecycle and preserves `ZK(... timeout=10, force_udp=False, ommit_ping=False)` behavior |
 | `PubSubMessenger` | `messaging.pubsub` | Owns publish, subscription existence/creation, targeted sync pull, ACK behavior, constants |
-| `SnapshotStore` | `storage.snapshot` | Reads/writes existing `snapshot.json` keys exactly: `pi4_state`, `sys_flags`, `sheet_id`, `last_stored_timestamp` |
-| `ReviewPeriodStore` | `storage.review_period` | Reads/writes existing review-period JSON unchanged |
+| `Snapshot persistence helpers` | `storage.snapshot` | Superseded by ETLP-24; function-based load_snapshot()/save_snapshot(RuntimeState) persistence |
+| `ReviewPeriod persistence helpers` | `storage.review_period` | Superseded by ETLP-24; function-based load_review_period()/save_review_period(ReviewPeriod) persistence |
 | `PiState` | `pi4.state` | Replaces mutable module globals with one runtime state object |
 | `IngestionWorkflow` | `pi4.workflow` | Owns transition rules, handler table, review-period timing policy, and record relay orchestration |
 | `PiRuntime` | `pi4.runtime` | Composition root: load config, instantiate concrete device/messenger/stores/workflow, run forever |
@@ -66,8 +80,8 @@ attendance_etl/
 | `get_attendance_records` | `IngestionWorkflow.get_attendance_records`, using `AttendanceDevice` plus transform functions |
 | `review_period_expired`, `wait_duration_before_next_pull` | `pi4.workflow` pure helpers or workflow methods, preserving Friday-to-Sunday extension and local `datetime.today()` behavior |
 | `publish_message_to_topic`, `subscription_exists`, `create_subscription`, `is_directed_to_me`, `sync_pull_message` | `PubSubMessenger` methods |
-| `save_review_period` | `ReviewPeriodStore.save` called by workflow |
-| `capture_snapshot` | `SnapshotStore.save` called only through workflow transition policy |
+| `save_review_period` | `save_review_period(ReviewPeriod) called by workflow` |
+| `capture_snapshot` | `save_snapshot(RuntimeState) called only through workflow transition policy` |
 | `transition_state` | `IngestionWorkflow.transition_state` |
 | All `handler_*` functions | Bound methods on `IngestionWorkflow` |
 | `setup_device_info`, `setup_review_period_info`, `setup_handler_table`, `load_snapshot` | `PiRuntime.bootstrap` plus store/state helpers |
@@ -85,11 +99,10 @@ src/pi4/pi4_client.py
       -> attendance_etl.storage.review_period
       -> attendance_etl.pi4.workflow
         -> attendance_etl.pi4.state
-        -> attendance_etl.device.interfaces
         -> attendance_etl.transform.zkteco_records
 ```
 
-Dependency rules: transform imports no infrastructure; device/messaging/storage do not import workflow; runtime is the only place that chooses `ZKTecoDevice`; workflow depends on the `AttendanceDevice` seam, not a multi-vendor abstraction.
+Note: the original proposal referenced an `AttendanceDevice` abstraction. This was later deferred to Milestone 3 — Device Layer Abstraction and should not be treated as implemented architecture.
 
 ## Behaviour-Preservation Risks
 
@@ -108,7 +121,7 @@ Dependency rules: transform imports no infrastructure; device/messaging/storage 
 1. Add characterization tests around pure transforms, review-period timing, snapshot transition rules, and Pub/Sub behavior using fakes/mocks.
 2. Extract stateless transform functions and constants first; keep facade imports/wrappers in `attendance_etl.ingestion.client`.
 3. Extract `ZKTecoDevice` and `PubSubMessenger` without changing call order, constructor arguments, topics, or payload serialization.
-4. Introduce `PiState`, stores, `IngestionWorkflow`, and `PiRuntime`; migrate handlers as bound methods while preserving the state table.
+4. Introduce PiState, persistence helpers, IngestionWorkflow, and PiRuntime; migrate handlers as bound methods while preserving the state table.
 5. Reduce `attendance_etl.ingestion.client` to the compatibility facade and keep `src/pi4/pi4_client.py` delegating to it.
 6. Update architecture/data-pipeline/reliability docs only to describe the new module ownership; do not document canonical adoption as implemented.
 7. Run required validation and produce an acceptance-criteria audit.
@@ -123,3 +136,227 @@ Dependency rules: transform imports no infrastructure; device/messaging/storage 
 - Focused tests cover transform behavior, workflow transition/snapshot policy, review-period timing, and Pub/Sub wrapper behavior with mocked clients.
 - `./scripts/validate.sh` passes before reporting completion; any targeted pytest command added for ETLP-21 also passes.
 - Final implementation report includes a PASS/FAIL acceptance-criteria audit and identifies any deliberately preserved legacy quirks.
+
+## ETLP-24 Review Findings
+
+### Summary
+
+The initial ETLP-24 implementation successfully introduced the required domain model classes but did not fully satisfy the acceptance criterion:
+
+    Models are used as shared data contracts between modules.
+
+Several models were created without fully replacing the existing dictionary-based contracts used throughout the ingestion pipeline.
+
+### Model Adoption Principle
+
+Creating a model is not sufficient.
+
+A model migration is considered complete only when internal module boundaries exchange model instances rather than dictionaries.
+
+Dictionaries should exist only at:
+
+- persistence boundaries
+- serialization boundaries
+- deserialization boundaries
+- external integration boundaries
+
+### Serialization Contracts
+
+Domain models should implement:
+
+    ISerializable
+    IDeserializable
+
+ISerializable:
+
+    to_dict() -> Dict[str, Any]
+
+IDeserializable:
+
+    from_dict(payload: Dict[str, Any])
+
+Models own serialization and deserialization.
+
+Persistence components own file I/O.
+
+### AttendanceEvent
+
+AttendanceEvent has been introduced but is not yet fully adopted throughout the ingestion pipeline.
+
+ETLP-24 should:
+
+- define AttendanceEvent ownership
+- define AttendanceEvent serialization semantics
+- define AttendanceEvent deserialization semantics
+
+ETLP-24 should not prematurely consume Transformation Layer scope.
+
+Full canonical attendance-event adoption is deferred.
+
+### Employee
+
+Employee should become the canonical representation of a device user.
+
+Preferred representation:
+
+    Dict[user_id, Employee]
+
+Employee objects should remain alive throughout the ingestion workflow rather than being flattened back into dictionaries or primitive values.
+
+### RuntimeState
+
+RuntimeState should become the canonical representation of persisted ingestion runtime state.
+
+RuntimeState owns:
+
+- serialization
+- deserialization
+
+Snapshot persistence owns:
+
+- file I/O
+- storage mechanics
+
+Target API:
+
+    load_snapshot() -> RuntimeState
+    save_snapshot(RuntimeState)
+
+### ReviewPeriod
+
+ReviewPeriod should become the canonical representation of review-period information.
+
+ReviewPeriod owns:
+
+- serialization
+- deserialization
+
+Review-period persistence owns:
+
+- file I/O
+- storage mechanics
+
+Target API:
+
+    load_review_period() -> ReviewPeriod
+    save_review_period(ReviewPeriod)
+
+### Anti-Patterns Identified
+
+The following are considered migration anti-patterns:
+
+- creating models and immediately converting them back into dictionaries
+- preserving old dictionary contracts internally after introducing models
+- introducing compatibility helpers that become the primary code path
+- introducing architectural abstractions not justified by the roadmap, ticket, or approved design review
+
+### Remaining ETLP-24 Work
+
+The following work remains within ETLP-24 scope:
+
+#### Phase A — Model Contract Foundation
+
+Objectives:
+
+- Introduce ISerializable
+- Introduce IDeserializable
+- Review model field ownership
+- Define explicit serialization contracts
+
+Applies to:
+
+- AttendanceEvent
+- Employee
+- ReviewPeriod
+- RuntimeState
+
+#### Phase B — RuntimeState And ReviewPeriod Adoption
+
+Objectives:
+
+- Remove internal RuntimeState dictionaries
+- Remove internal ReviewPeriod dictionaries
+- Use RuntimeState and ReviewPeriod as shared data contracts
+
+#### Phase C — Employee Adoption
+
+Objectives:
+
+Replace:
+
+    Dict[user_id, str]
+
+with:
+
+    Dict[user_id, Employee]
+
+throughout the ingestion client.
+
+#### Phase D — AttendanceEvent Preparation
+
+Objectives:
+
+- Finalise AttendanceEvent serialization semantics
+- Finalise AttendanceEvent deserialization semantics
+- Prepare AttendanceEvent for future canonical-pipeline adoption
+
+### Deferred Work
+
+The following work is intentionally deferred because dedicated roadmap items already exist.
+
+#### Device Abstraction Evolution
+
+Milestone:
+
+    3. Device Layer Abstraction
+
+Relevant Issues:
+
+- Create Device Interface
+- Implement ZKTeco Adapter
+- Implement Device Factory
+- Move Extraction Logic
+
+#### Canonical Attendance Event Adoption
+
+Milestone:
+
+    4. Transformation Layer
+
+Relevant Issues:
+
+- Create Transformation Module
+- Implement Canonical Transformer
+- Add Validation Logic
+- Implement Data Normalisation
+
+Reason:
+
+Canonical attendance-event adoption belongs to the Transformation Layer milestone and should not be consumed by ETLP-24.
+
+#### Messaging Abstraction Evolution
+
+Milestone:
+
+    5. Messaging Abstraction
+
+Relevant Issues:
+
+- Create Messaging Interface
+- Implement Pub/Sub Adapter
+- Move Messaging Logic
+- Implement Retry Handling
+
+Reason:
+
+Messaging redesign belongs to the Messaging Abstraction milestone and should not be consumed by ETLP-24.
+
+### ETLP-24 Exit Criteria
+
+ETLP-24 should only be considered complete once:
+
+- RuntimeState is the runtime persistence contract.
+- ReviewPeriod is the review-period persistence contract.
+- Employee is the user identity contract.
+- Model serialization/deserialization contracts are defined.
+- Models are used as shared data contracts between modules.

--- a/src/attendance_etl/models/__init__.py
+++ b/src/attendance_etl/models/__init__.py
@@ -1,0 +1,16 @@
+"""Core domain models shared across attendance ETL modules."""
+
+from attendance_etl.models.attendance_event import AttendanceEvent
+from attendance_etl.models.employee import Employee
+from attendance_etl.models.interfaces import IDeserializable, ISerializable
+from attendance_etl.models.review_period import ReviewPeriod
+from attendance_etl.models.runtime_state import RuntimeState
+
+__all__ = [
+    "AttendanceEvent",
+    "Employee",
+    "IDeserializable",
+    "ISerializable",
+    "ReviewPeriod",
+    "RuntimeState",
+]

--- a/src/attendance_etl/models/attendance_event.py
+++ b/src/attendance_etl/models/attendance_event.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+ATTENDANCE_TIMESTAMP_FORMAT = "%d-%m-%Y %H:%M:%S"
+
+
+def _parse_datetime(value: str) -> datetime:
+    try:
+        return datetime.strptime(value, ATTENDANCE_TIMESTAMP_FORMAT)
+    except ValueError:
+        pass
+
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+
+
+@dataclass
+class AttendanceEvent:
+    """Attendance event model prepared for current and canonical payloads."""
+
+    source_device_id: str
+    event_timestamp: datetime
+    employee_name: Optional[str] = None
+    raw_event_type: Optional[str] = None
+    employee_id: Optional[str] = None
+    event_type: Optional[str] = None
+    event_id: Optional[str] = None
+    ingested_at: Optional[datetime] = None
+    source_record_id: Optional[str] = None
+    site_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "username": self.employee_name,
+            "timestamp": self.event_timestamp.strftime(ATTENDANCE_TIMESTAMP_FORMAT),
+            "entry": self.raw_event_type or self.event_type,
+            "device": self.source_device_id,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "AttendanceEvent":
+        if "timestamp" in payload:
+            return cls(
+                source_device_id=payload["device"],
+                event_timestamp=_parse_datetime(payload["timestamp"]),
+                employee_name=payload.get("username"),
+                raw_event_type=payload.get("entry"),
+                event_type=payload.get("event_type"),
+                employee_id=payload.get("employee_id"),
+                event_id=payload.get("event_id"),
+                ingested_at=_parse_datetime(payload["ingested_at"]) if payload.get("ingested_at") else None,
+                source_record_id=payload.get("source_record_id"),
+                site_id=payload.get("site_id"),
+                metadata=dict(payload.get("metadata", {})),
+            )
+
+        return cls(
+            source_device_id=payload["source_device_id"],
+            event_timestamp=_parse_datetime(payload["event_timestamp"]),
+            employee_name=payload.get("employee_name"),
+            raw_event_type=payload.get("raw_event_type"),
+            employee_id=payload.get("employee_id"),
+            event_type=payload.get("event_type"),
+            event_id=payload.get("event_id"),
+            ingested_at=_parse_datetime(payload["ingested_at"]) if payload.get("ingested_at") else None,
+            source_record_id=payload.get("source_record_id"),
+            site_id=payload.get("site_id"),
+            metadata=dict(payload.get("metadata", {})),
+        )

--- a/src/attendance_etl/models/employee.py
+++ b/src/attendance_etl/models/employee.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class Employee:
+    """Minimal employee representation used for source-device user mapping."""
+
+    employee_id: str
+    name: Optional[str] = None
+    source_device_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_zkteco_user(cls, user: Any, source_device_id: Optional[str] = None) -> "Employee":
+        return cls(
+            employee_id=str(user.user_id),
+            name=getattr(user, "name", None),
+            source_device_id=source_device_id,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "employee_id": self.employee_id,
+            "name": self.name,
+            "source_device_id": self.source_device_id,
+        }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "Employee":
+        return cls(
+            employee_id=payload["employee_id"],
+            name=payload.get("name"),
+            source_device_id=payload.get("source_device_id"),
+            metadata=dict(payload.get("metadata", {})),
+        )

--- a/src/attendance_etl/models/interfaces.py
+++ b/src/attendance_etl/models/interfaces.py
@@ -1,0 +1,13 @@
+from typing import Any, Dict, Protocol, Type, TypeVar
+
+
+class ISerializable(Protocol):
+    def to_dict(self) -> Dict[str, Any]: ...
+
+
+T = TypeVar("T")
+
+
+class IDeserializable(Protocol):
+    @classmethod
+    def from_dict(cls: Type[T], payload: Dict[str, Any]) -> T: ...

--- a/src/attendance_etl/models/review_period.py
+++ b/src/attendance_etl/models/review_period.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+REVIEW_PERIOD_DATE_FORMAT = "%m/%d/%Y"
+
+
+@dataclass
+class ReviewPeriod:
+    """Review-period contract backed by the legacy review_period.json shape."""
+
+    start: datetime
+    end: datetime
+    sheet_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "start_date": self.start.strftime(REVIEW_PERIOD_DATE_FORMAT),
+            "end_date": self.end.strftime(REVIEW_PERIOD_DATE_FORMAT),
+        }
+        if self.sheet_id is not None:
+            payload["sheet_id"] = self.sheet_id
+        payload.update(self.metadata)
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "ReviewPeriod":
+        metadata = {key: value for key, value in payload.items() if key not in {"start_date", "end_date", "sheet_id"}}
+        return cls(
+            start=datetime.strptime(payload["start_date"], REVIEW_PERIOD_DATE_FORMAT),
+            end=datetime.strptime(payload["end_date"], REVIEW_PERIOD_DATE_FORMAT),
+            sheet_id=payload.get("sheet_id"),
+            metadata=metadata,
+        )

--- a/src/attendance_etl/models/runtime_state.py
+++ b/src/attendance_etl/models/runtime_state.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+RUNTIME_TIMESTAMP_FORMAT = "%d-%m-%Y %H:%M:%S"
+
+
+@dataclass
+class RuntimeState:
+    """Persisted ingestion runtime state backed by the legacy snapshot.json shape."""
+
+    pi4_state: int
+    sys_flags: int
+    sheet_id: Optional[str]
+    last_stored_timestamp: Optional[datetime] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        last_stored_timestamp = None
+        if self.last_stored_timestamp is not None:
+            last_stored_timestamp = self.last_stored_timestamp.strftime(RUNTIME_TIMESTAMP_FORMAT)
+
+        return {
+            "pi4_state": self.pi4_state,
+            "sys_flags": self.sys_flags,
+            "sheet_id": self.sheet_id,
+            "last_stored_timestamp": last_stored_timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "RuntimeState":
+        timestamp = payload["last_stored_timestamp"]
+        if isinstance(timestamp, str):
+            timestamp = datetime.strptime(timestamp, RUNTIME_TIMESTAMP_FORMAT)
+
+        return cls(
+            pi4_state=payload["pi4_state"],
+            sys_flags=payload["sys_flags"],
+            sheet_id=payload["sheet_id"],
+            last_stored_timestamp=timestamp,
+        )

--- a/src/attendance_etl/pi4/runtime.py
+++ b/src/attendance_etl/pi4/runtime.py
@@ -7,8 +7,8 @@ from attendance_etl.logging_utils import configure_logging, get_logger
 from attendance_etl.messaging.pubsub import PubSubMessenger
 from attendance_etl.pi4.state import Pi4RuntimeState
 from attendance_etl.pi4.workflow import Pi4Workflow
-from attendance_etl.storage.review_period import ReviewPeriodStore
-from attendance_etl.storage.snapshot import SnapshotStore
+from attendance_etl.storage.review_period import load_review_period
+from attendance_etl.storage.snapshot import load_snapshot
 
 logger = get_logger("Pi4Runtime")
 
@@ -25,15 +25,15 @@ def setup_device_info(path=config.BIOMETRIC_DEVICE_CONFIG_FILE):
     return device_info
 
 
-def load_snapshot_into_state(snapshot_store, state):
-    snapshot = snapshot_store.load()
-    state.pi4_state = snapshot["pi4_state"]
-    state.system_flags = snapshot["sys_flags"]
-    state.review_sheet_id = snapshot["sheet_id"]
-    state.last_stored_timestamp = snapshot["last_stored_timestamp"]
+def load_snapshot_into_state(state, path=config.SNAPSHOT_FILE):
+    snapshot = load_snapshot(path)
+    state.pi4_state = snapshot.pi4_state
+    state.system_flags = snapshot.sys_flags
+    state.review_sheet_id = snapshot.sheet_id
+    state.last_stored_timestamp = snapshot.last_stored_timestamp
 
     logger.info(
-        "loaded snapshot: pi4 state = %s, review sheet id = %s, last stored timestamp = %s",
+        "loaded runtime state: pi4 state = %s, review sheet id = %s, last stored timestamp = %s",
         state.pi4_state,
         state.review_sheet_id,
         state.last_stored_timestamp,
@@ -52,15 +52,13 @@ def bootstrap_pi4(verbosity=logging.INFO):
     device = ZKTecoDevice(state.device_info["ip"], state.device_info["port"])
     messenger = PubSubMessenger(state.device_info["identifier"])
 
-    snapshot_store = SnapshotStore()
-    review_period_store = ReviewPeriodStore()
-
-    state.review_period_info = review_period_store.load()
+    review_period = load_review_period()
+    state.review_period_info = review_period.to_dict()
     logger.info("review period info: %s", state.review_period_info)
 
-    load_snapshot_into_state(snapshot_store, state)
+    load_snapshot_into_state(state)
 
-    return Pi4Workflow(state, device, messenger, snapshot_store, review_period_store)
+    return Pi4Workflow(state, device, messenger)
 
 
 def run(workflow):

--- a/src/attendance_etl/pi4/workflow.py
+++ b/src/attendance_etl/pi4/workflow.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, cast
 
 from attendance_etl import config
 from attendance_etl.logging_utils import get_logger
+from attendance_etl.models import ReviewPeriod, RuntimeState
 from attendance_etl.pi4.state import (
     AWAIT_LAST_STORED_TIMESTAMP,
     AWAIT_REVIEW_PERIOD,
@@ -17,18 +18,18 @@ from attendance_etl.pi4.state import (
     REVIEW_PERIOD_EXPIRED,
     WAITING_STATES,
 )
+from attendance_etl.storage.review_period import save_review_period
+from attendance_etl.storage.snapshot import save_snapshot
 from attendance_etl.transform.zkteco_records import convert_to_map, decode_zk_format, filter_records
 
 logger = get_logger("Pi4Workflow")
 
 
 class Pi4Workflow:
-    def __init__(self, state, device, messenger, snapshot_store, review_period_store):
+    def __init__(self, state, device, messenger):
         self.state = state
         self.device = device
         self.messenger = messenger
-        self.snapshot_store = snapshot_store
-        self.review_period_store = review_period_store
         self.handler_table = self.setup_handler_table()
 
     def setup_handler_table(self):
@@ -113,11 +114,17 @@ class Pi4Workflow:
         """
         Add annotation
         """
-        self.snapshot_store.save(
-            self.state.pi4_state,
-            self.state.system_flags,
-            self.state.review_sheet_id,
-            self.state.last_stored_timestamp,
+        last_stored_timestamp = self.state.last_stored_timestamp
+        if isinstance(last_stored_timestamp, str):
+            last_stored_timestamp = datetime.strptime(last_stored_timestamp, "%d-%m-%Y %H:%M:%S")
+
+        save_snapshot(
+            RuntimeState(
+                pi4_state=self.state.pi4_state,
+                sys_flags=self.state.system_flags,
+                sheet_id=self.state.review_sheet_id,
+                last_stored_timestamp=last_stored_timestamp,
+            )
         )
 
     def transition_state(self, new_state):
@@ -162,7 +169,7 @@ class Pi4Workflow:
             # update and save the new review period's info and transition
             # to the next state
             self.state.review_period_info = new_review_period
-            self.review_period_store.save(self.state.review_period_info)
+            save_review_period(ReviewPeriod.from_dict(new_review_period))
 
             next_state = REQUEST_REVIEW_SHEET
         else:  # denotes that the data for the next review period isn't available yet

--- a/src/attendance_etl/storage/review_period.py
+++ b/src/attendance_etl/storage/review_period.py
@@ -2,34 +2,27 @@ import json
 
 from attendance_etl import config
 from attendance_etl.logging_utils import get_logger
+from attendance_etl.models import ReviewPeriod
 
-logger = get_logger("ReviewPeriodStore")
-
-
-class ReviewPeriodStore:
-    def __init__(self, path=config.REVIEW_PERIOD_JSON):
-        self.path = path
-
-    def load(self):
-        return load_review_period(self.path)
-
-    def save(self, review_period_info):
-        save_review_period(review_period_info, self.path)
+logger = get_logger("ReviewPeriod")
 
 
-def load_review_period(path=config.REVIEW_PERIOD_JSON):
+def load_review_period(path=config.REVIEW_PERIOD_JSON) -> ReviewPeriod:
     """
-    loads the review period information from the json file
+    loads the review period information as the shared domain model.
     """
     logger.debug("loading review period from %s", path)
     with open(path) as json_file:
-        return json.load(json_file)
+        return ReviewPeriod.from_dict(json.load(json_file))
 
 
-def save_review_period(review_period_info, path=config.REVIEW_PERIOD_JSON):
+def save_review_period(review_period: ReviewPeriod, path=config.REVIEW_PERIOD_JSON) -> None:
     """
     saves the review period json to the disk
     """
+    if not isinstance(review_period, ReviewPeriod):
+        raise TypeError("save_review_period expects a ReviewPeriod instance")
+
     logger.debug("saving review period to %s", path)
     with open(path, "w") as json_file:
-        json.dump(review_period_info, json_file)
+        json.dump(review_period.to_dict(), json_file)

--- a/src/attendance_etl/storage/snapshot.py
+++ b/src/attendance_etl/storage/snapshot.py
@@ -2,53 +2,27 @@ import json
 
 from attendance_etl import config
 from attendance_etl.logging_utils import get_logger
+from attendance_etl.models import RuntimeState
 
 logger = get_logger("RuntimeState")
 
 
-class SnapshotStore:
-    def __init__(self, path=config.SNAPSHOT_FILE):
-        self.path = path
-
-    def load(self):
-        return load_snapshot(self.path)
-
-    def save(self, pi4_state, system_flags, review_sheet_id, last_stored_timestamp):
-        save_snapshot(
-            pi4_state=pi4_state,
-            system_flags=system_flags,
-            review_sheet_id=review_sheet_id,
-            last_stored_timestamp=last_stored_timestamp,
-            path=self.path,
-        )
-
-
-def load_snapshot(path=config.SNAPSHOT_FILE):
+def load_snapshot(path=config.SNAPSHOT_FILE) -> RuntimeState:
     """
-    loads the snapshot captured during checkpointing to resume operation
-    without losing state information in case of a (device) shutdown
+    loads the snapshot as the shared runtime state domain model.
     """
     logger.debug("loading runtime state from %s", path)
     with open(path) as json_file:
-        return json.load(json_file)
+        return RuntimeState.from_dict(json.load(json_file))
 
 
-def save_snapshot(
-    pi4_state,
-    system_flags,
-    review_sheet_id,
-    last_stored_timestamp,
-    path=config.SNAPSHOT_FILE,
-):
+def save_snapshot(runtime_state: RuntimeState, path=config.SNAPSHOT_FILE) -> None:
     """
     saves the runtime snapshot to disk using the legacy JSON shape.
     """
-    snapshot = {}
-    snapshot["pi4_state"] = pi4_state
-    snapshot["sys_flags"] = system_flags
-    snapshot["sheet_id"] = review_sheet_id
-    snapshot["last_stored_timestamp"] = last_stored_timestamp
+    if not isinstance(runtime_state, RuntimeState):
+        raise TypeError("save_snapshot expects a RuntimeState instance")
 
     logger.debug("saving runtime state to %s", path)
     with open(path, "w") as json_file:
-        json.dump(snapshot, json_file)
+        json.dump(runtime_state.to_dict(), json_file)

--- a/src/attendance_etl/transform/zkteco_records.py
+++ b/src/attendance_etl/transform/zkteco_records.py
@@ -1,4 +1,5 @@
 from attendance_etl.logging_utils import get_logger
+from attendance_etl.models import Employee
 
 logger = get_logger("RecordTransformer")
 
@@ -6,13 +7,14 @@ logger = get_logger("RecordTransformer")
 def convert_to_map(zk_users):
     """
     converts the list of users fetched from the biometric device
-    to a user id vs name map to allow a O(1) lookup for generating
+    to a user id vs Employee map to allow a O(1) lookup for generating
     a human readable equivalent of the attendance entries.
     """
     logger.debug("Generating user id to name mapping for %s users...", len(zk_users))
     user_mapping = {}
     for zk_user in zk_users:
-        user_mapping[zk_user.user_id] = zk_user.name
+        employee = Employee.from_zkteco_user(zk_user)
+        user_mapping[zk_user.user_id] = employee
 
     return user_mapping
 
@@ -22,7 +24,7 @@ def convert_to_dict(attendance_record, user_mapping):
     converts a ZKTeco attendance record to a dictionary that can
     be readily stored in the datastore.
     """
-    name = user_mapping[attendance_record.user_id]
+    name = user_mapping[attendance_record.user_id].name
     timestamp = attendance_record.timestamp
     entry_type = "Check In" if attendance_record.punch == 0 else "Check Out"
 

--- a/tests/unit/ingestion/test_config.py
+++ b/tests/unit/ingestion/test_config.py
@@ -7,18 +7,6 @@ from attendance_etl.messaging.pubsub import PubSubMessenger
 from attendance_etl.pi4 import runtime
 from attendance_etl.pi4.state import FETCH_REVIEW_PERIOD, Pi4RuntimeState
 from attendance_etl.pi4.workflow import Pi4Workflow
-from attendance_etl.storage.review_period import ReviewPeriodStore
-from attendance_etl.storage.snapshot import SnapshotStore
-
-
-class SnapshotSpy:
-    def save(self, pi4_state, system_flags, review_sheet_id, last_stored_timestamp):
-        pass
-
-
-class ReviewPeriodStoreSpy:
-    def save(self, review_period_info):
-        pass
 
 
 class DeviceStub:
@@ -102,8 +90,7 @@ class ConfigTests(unittest.TestCase):
             messenger.subscription_name(config.NEW_REVIEW_PERIOD_TOPIC),
             "sub_new_review_period_att-dev-dk-01",
         )
-        self.assertEqual(SnapshotStore().path, config.SNAPSHOT_FILE)
-        self.assertEqual(ReviewPeriodStore().path, config.REVIEW_PERIOD_JSON)
+        self.assertEqual(runtime.load_snapshot_into_state.__defaults__, (config.SNAPSHOT_FILE,))
         self.assertEqual(runtime.setup_device_info.__defaults__, (config.BIOMETRIC_DEVICE_CONFIG_FILE,))
 
     def test_workflow_publishes_to_configured_topics(self):
@@ -114,8 +101,6 @@ class ConfigTests(unittest.TestCase):
             state,
             DeviceStub(),
             messenger,
-            SnapshotSpy(),
-            ReviewPeriodStoreSpy(),
         )
 
         workflow.handler_fetch_review_period()

--- a/tests/unit/ingestion/test_models.py
+++ b/tests/unit/ingestion/test_models.py
@@ -1,0 +1,128 @@
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+
+from attendance_etl.models import AttendanceEvent, Employee, ReviewPeriod, RuntimeState
+
+
+class DomainModelTests(unittest.TestCase):
+    def test_attendance_event_to_dict_preserves_current_backend_payload_shape(self):
+        event = AttendanceEvent(
+            source_device_id="att-dev-dk-01",
+            event_timestamp=datetime(2026, 5, 27, 8, 59, 12),
+            employee_name="Ayesha Khan",
+            raw_event_type="Check In",
+        )
+
+        self.assertEqual(
+            event.to_dict(),
+            {
+                "username": "Ayesha Khan",
+                "timestamp": "27-05-2026 08:59:12",
+                "entry": "Check In",
+                "device": "att-dev-dk-01",
+            },
+        )
+
+    def test_attendance_event_from_dict_accepts_current_backend_payload_shape(self):
+        event = AttendanceEvent.from_dict(
+            {
+                "username": "Ayesha Khan",
+                "timestamp": "2026-05-27T08:59:12Z",
+                "entry": "Check In",
+                "device": "att-dev-dk-01",
+            }
+        )
+
+        self.assertEqual(event.employee_name, "Ayesha Khan")
+        self.assertEqual(event.event_timestamp.isoformat(), "2026-05-27T08:59:12+00:00")
+        self.assertEqual(event.raw_event_type, "Check In")
+        self.assertEqual(event.source_device_id, "att-dev-dk-01")
+        self.assertIsNone(event.event_id)
+        self.assertIsNone(event.employee_id)
+        self.assertIsNone(event.ingested_at)
+        self.assertEqual(event.metadata, {})
+
+    def test_attendance_event_model_retains_internal_semantics(self):
+        event = AttendanceEvent(
+            source_device_id="att-dev-dk-01",
+            event_timestamp=datetime(2026, 5, 27, 8, 59, 12),
+            employee_name="Ayesha Khan",
+            raw_event_type="Check In",
+            employee_id="10042",
+            event_type="clock_in",
+            event_id="att-dev-dk-01-10042-2026-05-27T08:59:12Z",
+            ingested_at=datetime(2026, 5, 27, 9, 0, 3),
+            source_record_id="zk-879221",
+            site_id="dk",
+            metadata={"source_format": "zkteco"},
+        )
+
+        self.assertEqual(event.event_id, "att-dev-dk-01-10042-2026-05-27T08:59:12Z")
+        self.assertEqual(event.source_device_id, "att-dev-dk-01")
+        self.assertEqual(event.employee_id, "10042")
+        self.assertEqual(event.event_timestamp, datetime(2026, 5, 27, 8, 59, 12))
+        self.assertEqual(event.event_type, "clock_in")
+        self.assertEqual(event.ingested_at, datetime(2026, 5, 27, 9, 0, 3))
+        self.assertEqual(event.source_record_id, "zk-879221")
+        self.assertEqual(event.employee_name, "Ayesha Khan")
+        self.assertEqual(event.site_id, "dk")
+        self.assertEqual(event.raw_event_type, "Check In")
+        self.assertEqual(event.metadata, {"source_format": "zkteco"})
+
+    def test_employee_from_zkteco_user_keeps_minimal_identity(self):
+        employee = Employee.from_zkteco_user(
+            SimpleNamespace(user_id="10042", name="Ayesha Khan"),
+            source_device_id="att-dev-dk-01",
+        )
+
+        self.assertEqual(employee.employee_id, "10042")
+        self.assertEqual(employee.name, "Ayesha Khan")
+        self.assertEqual(employee.source_device_id, "att-dev-dk-01")
+
+    def test_review_period_round_trip_preserves_legacy_keys_and_metadata(self):
+        payload = {
+            "month": "May",
+            "start_date": "05/01/2026",
+            "end_date": "05/29/2026",
+            "duration_weeks": 4,
+            "sheetname": "May Attendance",
+        }
+
+        review_period = ReviewPeriod.from_dict(payload)
+
+        self.assertEqual(review_period.start, datetime(2026, 5, 1))
+        self.assertEqual(review_period.end, datetime(2026, 5, 29))
+        self.assertEqual(review_period.to_dict(), payload)
+
+    def test_runtime_state_round_trip_preserves_snapshot_keys_and_timestamp_format(self):
+        payload = {
+            "pi4_state": 7,
+            "sys_flags": 1,
+            "sheet_id": "sheet-123",
+            "last_stored_timestamp": "27-05-2026 08:59:12",
+        }
+
+        runtime_state = RuntimeState.from_dict(payload)
+        serialized = runtime_state.to_dict()
+
+        self.assertEqual(runtime_state.last_stored_timestamp, datetime(2026, 5, 27, 8, 59, 12))
+        self.assertEqual(
+            set(serialized),
+            {"pi4_state", "sys_flags", "sheet_id", "last_stored_timestamp"},
+        )
+        self.assertEqual(serialized, payload)
+
+    def test_runtime_state_round_trip_preserves_null_timestamp_and_sheet_id(self):
+        payload = {
+            "pi4_state": 1,
+            "sys_flags": 0,
+            "sheet_id": None,
+            "last_stored_timestamp": None,
+        }
+
+        self.assertEqual(RuntimeState.from_dict(payload).to_dict(), payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/ingestion/test_pi4_workflow.py
+++ b/tests/unit/ingestion/test_pi4_workflow.py
@@ -1,5 +1,7 @@
 import unittest
 
+import attendance_etl.pi4.workflow as workflow_module
+from attendance_etl.models import RuntimeState
 from attendance_etl.pi4.state import (
     AWAIT_REVIEW_PERIOD,
     FETCH_REVIEW_PERIOD,
@@ -13,18 +15,11 @@ class SnapshotSpy:
     def __init__(self):
         self.saves = []
 
-    def save(self, pi4_state, system_flags, review_sheet_id, last_stored_timestamp):
-        self.saves.append(
-            {
-                "pi4_state": pi4_state,
-                "sys_flags": system_flags,
-                "sheet_id": review_sheet_id,
-                "last_stored_timestamp": last_stored_timestamp,
-            }
-        )
+    def save(self, runtime_state):
+        self.saves.append(runtime_state)
 
 
-class ReviewPeriodStoreSpy:
+class ReviewPeriodSaveSpy:
     def __init__(self):
         self.saved = []
 
@@ -52,34 +47,41 @@ class DeviceStub:
 
 
 class Pi4WorkflowTests(unittest.TestCase):
-    def make_workflow(self, state=None, messenger=None, snapshot_store=None, review_period_store=None):
+    def setUp(self):
+        self.original_save_snapshot = workflow_module.save_snapshot
+        self.original_save_review_period = workflow_module.save_review_period
+
+    def tearDown(self):
+        workflow_module.save_snapshot = self.original_save_snapshot
+        workflow_module.save_review_period = self.original_save_review_period
+
+    def make_workflow(self, state=None, messenger=None):
         return Pi4Workflow(
             state or Pi4RuntimeState(),
             DeviceStub(),
             messenger or MessengerStub({}),
-            snapshot_store or SnapshotSpy(),
-            review_period_store or ReviewPeriodStoreSpy(),
         )
 
     def test_transition_skips_snapshot_for_waiting_states(self):
-        snapshot_store = SnapshotSpy()
+        snapshot_saver = SnapshotSpy()
+        workflow_module.save_snapshot = snapshot_saver.save
         state = Pi4RuntimeState(
             pi4_state=FETCH_REVIEW_PERIOD,
             system_flags=1,
             review_sheet_id="sheet-123",
             last_stored_timestamp="27-05-2026 08:59:12",
         )
-        workflow = self.make_workflow(state=state, snapshot_store=snapshot_store)
+        workflow = self.make_workflow(state=state)
 
         workflow.transition_state(AWAIT_REVIEW_PERIOD)
 
         self.assertEqual(state.pi4_state, AWAIT_REVIEW_PERIOD)
-        self.assertEqual(snapshot_store.saves, [])
+        self.assertEqual(snapshot_saver.saves, [])
 
         workflow.transition_state(FETCH_REVIEW_PERIOD)
 
         self.assertEqual(
-            snapshot_store.saves,
+            [snapshot.to_dict() for snapshot in snapshot_saver.saves],
             [
                 {
                     "pi4_state": FETCH_REVIEW_PERIOD,
@@ -91,22 +93,23 @@ class Pi4WorkflowTests(unittest.TestCase):
         )
 
     def test_empty_review_period_preserves_final_alarm_flag_as_next_state_value(self):
-        snapshot_store = SnapshotSpy()
-        review_period_store = ReviewPeriodStoreSpy()
+        snapshot_saver = SnapshotSpy()
+        review_period_saver = ReviewPeriodSaveSpy()
+        workflow_module.save_snapshot = snapshot_saver.save
+        workflow_module.save_review_period = review_period_saver.save
         state = Pi4RuntimeState(system_flags=0)
         workflow = self.make_workflow(
             state=state,
             messenger=MessengerStub({}),
-            snapshot_store=snapshot_store,
-            review_period_store=review_period_store,
         )
 
         workflow.handler_await_review_period()
 
         self.assertEqual(FINAL_ALARM_RAISED, FETCH_REVIEW_PERIOD)
         self.assertEqual(state.pi4_state, FETCH_REVIEW_PERIOD)
-        self.assertEqual(review_period_store.saved, [])
-        self.assertEqual(snapshot_store.saves[0]["pi4_state"], FETCH_REVIEW_PERIOD)
+        self.assertEqual(review_period_saver.saved, [])
+        self.assertIsInstance(snapshot_saver.saves[0], RuntimeState)
+        self.assertEqual(snapshot_saver.saves[0].pi4_state, FETCH_REVIEW_PERIOD)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ingestion/test_runtime_state_boundary.py
+++ b/tests/unit/ingestion/test_runtime_state_boundary.py
@@ -1,0 +1,43 @@
+import unittest
+from datetime import datetime
+
+import attendance_etl.pi4.runtime as runtime_module
+from attendance_etl.models import RuntimeState
+from attendance_etl.pi4.runtime import load_snapshot_into_state
+from attendance_etl.pi4.state import Pi4RuntimeState
+
+
+class RuntimeStateBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        self.original_load_snapshot = runtime_module.load_snapshot
+
+    def tearDown(self):
+        runtime_module.load_snapshot = self.original_load_snapshot
+
+    def test_load_snapshot_into_state_consumes_runtime_state_attributes(self):
+        snapshot = RuntimeState.from_dict(
+            {
+                "pi4_state": 7,
+                "sys_flags": 1,
+                "sheet_id": "sheet-123",
+                "last_stored_timestamp": "27-05-2026 08:59:12",
+            }
+        )
+
+        def fail_to_dict():
+            raise AssertionError("runtime should consume RuntimeState attributes directly")
+
+        snapshot.to_dict = fail_to_dict
+        state = Pi4RuntimeState()
+        runtime_module.load_snapshot = lambda path: snapshot
+
+        load_snapshot_into_state(state, "snapshot.json")
+
+        self.assertEqual(state.pi4_state, 7)
+        self.assertEqual(state.system_flags, 1)
+        self.assertEqual(state.review_sheet_id, "sheet-123")
+        self.assertEqual(state.last_stored_timestamp, datetime(2026, 5, 27, 8, 59, 12))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/ingestion/test_storage_persistence.py
+++ b/tests/unit/ingestion/test_storage_persistence.py
@@ -2,7 +2,11 @@ import json
 import os
 import tempfile
 import unittest
+from datetime import datetime
 
+import attendance_etl.storage.review_period as review_period_module
+import attendance_etl.storage.snapshot as snapshot_module
+from attendance_etl.models import ReviewPeriod, RuntimeState
 from attendance_etl.storage.review_period import load_review_period, save_review_period
 from attendance_etl.storage.snapshot import load_snapshot, save_snapshot
 
@@ -11,14 +15,14 @@ class StoragePersistenceTests(unittest.TestCase):
     def test_snapshot_load_save_preserves_legacy_shape(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "snapshot.json")
-
-            save_snapshot(
+            runtime_state = RuntimeState(
                 pi4_state=7,
-                system_flags=1,
-                review_sheet_id="sheet-123",
-                last_stored_timestamp="27-05-2026 08:59:12",
-                path=path,
+                sys_flags=1,
+                sheet_id="sheet-123",
+                last_stored_timestamp=datetime(2026, 5, 27, 8, 59, 12),
             )
+
+            save_snapshot(runtime_state, path)
 
             with open(path) as json_file:
                 raw = json.load(json_file)
@@ -32,7 +36,46 @@ class StoragePersistenceTests(unittest.TestCase):
                     "last_stored_timestamp": "27-05-2026 08:59:12",
                 },
             )
-            self.assertEqual(load_snapshot(path), raw)
+
+            helper_snapshot = load_snapshot(path)
+            self.assertIsInstance(helper_snapshot, RuntimeState)
+            self.assertEqual(helper_snapshot.to_dict(), raw)
+
+    def test_snapshot_save_accepts_runtime_state_and_preserves_legacy_shape(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "snapshot.json")
+
+            save_snapshot(
+                RuntimeState(
+                    pi4_state=3,
+                    sys_flags=4,
+                    sheet_id=None,
+                    last_stored_timestamp=datetime(2026, 5, 28, 10, 11, 12),
+                ),
+                path,
+            )
+
+            with open(path) as json_file:
+                self.assertEqual(
+                    json.load(json_file),
+                    {
+                        "pi4_state": 3,
+                        "sys_flags": 4,
+                        "sheet_id": None,
+                        "last_stored_timestamp": "28-05-2026 10:11:12",
+                    },
+                )
+
+    def test_removed_model_helper_no_longer_exists(self):
+        removed_helper = "_".join(("load_snapshot", "model"))
+        self.assertFalse(hasattr(snapshot_module, removed_helper))
+
+    def test_persistence_wrapper_classes_do_not_exist(self):
+        removed_snapshot_wrapper = "".join(("Snapshot", "Store"))
+        removed_review_period_wrapper = "".join(("ReviewPeriod", "Store"))
+
+        self.assertFalse(hasattr(snapshot_module, removed_snapshot_wrapper))
+        self.assertFalse(hasattr(review_period_module, removed_review_period_wrapper))
 
     def test_review_period_load_save_preserves_json_shape(self):
         review_period = {
@@ -44,9 +87,11 @@ class StoragePersistenceTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "review_period.json")
 
-            save_review_period(review_period, path)
+            save_review_period(ReviewPeriod.from_dict(review_period), path)
 
-            self.assertEqual(load_review_period(path), review_period)
+            review_period_model = load_review_period(path)
+            self.assertIsInstance(review_period_model, ReviewPeriod)
+            self.assertEqual(review_period_model.to_dict(), review_period)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ingestion/test_zkteco_records.py
+++ b/tests/unit/ingestion/test_zkteco_records.py
@@ -2,7 +2,8 @@ import unittest
 from datetime import datetime
 from types import SimpleNamespace
 
-from attendance_etl.transform.zkteco_records import convert_to_map, decode_zk_format, filter_records
+from attendance_etl.models import Employee
+from attendance_etl.transform.zkteco_records import convert_to_dict, convert_to_map, decode_zk_format, filter_records
 
 
 class ZKTecoRecordTransformTests(unittest.TestCase):
@@ -26,6 +27,33 @@ class ZKTecoRecordTransformTests(unittest.TestCase):
                 }
             ],
         )
+
+    def test_convert_to_map_returns_employee_values_by_user_id(self):
+        users = [SimpleNamespace(user_id=10042, name="Ayesha Khan")]
+
+        user_mapping = convert_to_map(users)
+
+        self.assertEqual(list(user_mapping), [10042])
+        self.assertIsInstance(user_mapping[10042], Employee)
+        self.assertEqual(user_mapping[10042].employee_id, "10042")
+        self.assertEqual(user_mapping[10042].name, "Ayesha Khan")
+        self.assertIsNone(user_mapping[10042].source_device_id)
+
+    def test_convert_to_dict_preserves_external_attendance_payload_shape(self):
+        users = [SimpleNamespace(user_id="10042", name="Ayesha Khan")]
+        record = SimpleNamespace(user_id="10042", timestamp=datetime(2026, 5, 27, 8, 59, 12), punch=1)
+
+        decoded = convert_to_dict(record, convert_to_map(users))
+
+        self.assertEqual(
+            decoded,
+            {
+                "username": "Ayesha Khan",
+                "timestamp": "27-05-2026 08:59:12",
+                "entry": "Check Out",
+            },
+        )
+        self.assertEqual(set(decoded), {"username", "timestamp", "entry"})
 
     def test_filter_records_preserves_exclusive_start_and_inclusive_end(self):
         records = [


### PR DESCRIPTION
<!--
planning_metadata:
  estimated_effort: 1.5h
  priority: Highest
  milestone_id: 2
  milestone: "2. Repository Structure Modernisation"
-->

## Summary
Create explicit data models for core domain objects.

## Should have
- Create AttendanceEvent
- Create Employee
- Create ReviewPeriod
- Create RuntimeState

## Nice to have
- Add simple conversion helpers

## Acceptance criteria
- [x] Core domain models exist
- [x] Models are used as shared data contracts between modules
