### PR TITLE
ETLP-28: Moves extraction into device abstraction

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,7 +81,9 @@ toward more explicit ingestion boundaries.
 
 The Raspberry Pi ingestion client is split into focused package modules:
 
-- `attendance_etl.devices.biometric_device` owns the runtime-facing biometric device abstraction.
+- `attendance_etl.devices.biometric_device` owns the runtime-facing biometric device abstraction. A
+  `BiometricDevice` is a commissioned biometric terminal deployed at a known office site, and every instance
+  exposes its configured `site_id` as read-only runtime identity.
 - `attendance_etl.devices.biometric_device_factory` owns concrete biometric device construction.
 - `attendance_etl.devices.zkteco_device` owns ZKTeco SDK integration, ZKTeco connection lifecycle, device
   reads, attendance clearing, and ZKTeco implementation-level defaults.
@@ -135,6 +137,12 @@ are extracted. It is deployment/domain metadata, independent of the biometric
 device vendor and communication mechanism. It may later be propagated into
 canonical attendance records as source-site metadata.
 
+`BiometricDeviceConfig.site_id` is the source of the commissioned device runtime
+identity. `BiometricDeviceFactory` passes this value into concrete
+`BiometricDevice` instances during construction. Because a `BiometricDevice`
+already owns its site identity, runtime callers must not pass `site_id` into
+`extract_attendance_records(...)`.
+
 `vendor` selects the biometric device implementation.
 
 `device_options` contains vendor-specific connection metadata.
@@ -174,7 +182,8 @@ The ownership boundaries are:
 - `VendorOptions`: vendor-specific configuration abstraction.
 - `ZKTecoOptions`: ZKTeco-specific connection options.
 - `BiometricDeviceFactory`: concrete `BiometricDevice` construction from a
-  validated `BiometricDeviceConfig`.
+  validated `BiometricDeviceConfig`, including passing root `site_id` into the
+  commissioned device instance.
 - `ZKTecoDevice`: pyzk integration, device communication, extraction, clearing,
   and ZKTeco-specific implementation defaults.
 

--- a/docs/decisions/0003-device-and-transformation-layer-boundaries.md
+++ b/docs/decisions/0003-device-and-transformation-layer-boundaries.md
@@ -137,6 +137,17 @@ are extracted.
 device vendor and communication mechanism, and it may later be propagated into
 canonical attendance records as source-site metadata.
 
+Every `BiometricDevice` instance represents a commissioned biometric terminal
+deployed at a known office site. `BiometricDeviceConfig.site_id` is the source of
+that runtime identity. Concrete biometric devices shall receive `site_id` during
+construction and expose it through the read-only `BiometricDevice.site_id`
+property.
+
+Because a commissioned `BiometricDevice` already owns its site identity,
+`extract_attendance_records(...)` shall not require `site_id` as a parameter.
+Concrete device implementations shall use their own `site_id` when decoding or
+emitting existing transitional attendance dictionaries.
+
 `vendor` selects the biometric device implementation.
 
 `device_options` contains vendor-specific connection metadata.
@@ -220,6 +231,9 @@ The factory consumes validated `BiometricDeviceConfig` and returns the
 
 It does not read JSON configuration files and it does not own configuration
 validation.
+
+The factory is responsible for passing `BiometricDeviceConfig.site_id` into the
+concrete commissioned device instance it constructs.
 
 ## Decision 5: Device Access And Data Transformation Are Separate Concerns
 
@@ -339,6 +353,7 @@ should require modification.
 | Runtime imports vendor SDKs directly | Leaks low-level implementation details into high-level policy code and increases coupling to vendor-specific dependencies. |
 | ZKTeco fields on `BiometricDeviceConfig` | Leaks vendor-specific connection details into the root runtime configuration contract. |
 | `site_id` inside `VendorOptions` or `ZKTecoOptions` | Couples deployment/domain metadata to vendor-specific connection configuration. |
+| Passing `site_id` into `extract_attendance_records(...)` | Treats commissioned device identity as per-call input even though the device instance already owns that runtime identity. |
 | `BiometricDeviceFactory` reads JSON directly | Mixes file loading, validation, and concrete object construction in one boundary. |
 
 ## References

--- a/docs/proposals/device-layer-abstraction.md
+++ b/docs/proposals/device-layer-abstraction.md
@@ -138,6 +138,12 @@ are extracted. It is deployment/domain metadata, independent of the biometric
 device vendor and communication mechanism, and may later be propagated into
 canonical attendance records as source-site metadata.
 
+`site_id` also defines the runtime identity of a commissioned `BiometricDevice`.
+Every `BiometricDevice` instance represents a biometric terminal deployed at a
+known office site and exposes this value through a read-only `site_id` property.
+The value originates from `BiometricDeviceConfig` and is passed into the
+concrete device by `BiometricDeviceFactory` during construction.
+
 `vendor` selects the biometric device implementation.
 
 `device_options` contains vendor-specific connection metadata.
@@ -246,6 +252,7 @@ Forbidden dependencies:
 The device layer owns:
 
 - device connection lifecycle
+- read-only commissioned device identity
 - extraction
 - device communication
 - attendance record clearing
@@ -269,6 +276,7 @@ BiometricDevice is responsible for:
 
 - connecting to devices
 - disconnecting from devices
+- exposing read-only `site_id` for the commissioned terminal
 - extracting users
 - extracting attendance records
 - clearing attendance records
@@ -293,7 +301,9 @@ The interface should remain focused on device access.
 
 It should not own transformation responsibilities.
 
-Exact method signatures are intentionally left flexible and should be derived from the current SDK integration during ETLP-25.
+`extract_attendance_records(...)` must not accept `site_id` as a parameter.
+Callers already hold a commissioned `BiometricDevice`, and the device owns the
+site identity needed for existing transitional payload decoding.
 
 ## BiometricDeviceFactory Contract
 
@@ -305,6 +315,7 @@ BiometricDeviceFactory acts as the composition boundary.
 - wire required dependencies
 - hide concrete biometric device construction from runtime code
 - consume BiometricDeviceConfig
+- pass `BiometricDeviceConfig.site_id` into commissioned device instances
 
 ### Non-Responsibilities
 
@@ -415,10 +426,14 @@ Move extraction responsibilities behind the device boundary.
 
 - Device extraction logic moved into ZKTecoDevice
 - Runtime orchestration simplified
+- `site_id` owned by the commissioned BiometricDevice instance
 
 ### Acceptance Criteria
 
 - Runtime and workflow no longer contain device-specific extraction logic
+- Workflow calls `extract_attendance_records(...)` without passing `site_id`
+- BiometricDevice exposes read-only `site_id`
+- BiometricDeviceFactory passes `BiometricDeviceConfig.site_id` into concrete devices
 - Extraction behaviour remains unchanged
 - Existing tests continue to pass
 
@@ -451,6 +466,7 @@ Milestone 3 is considered complete when:
 - Extraction logic resides within the device layer
 - BiometricDeviceConfig contains root `site_id`, `vendor`, and `device_options`
 - BiometricDeviceConfig is vendor-neutral at the root level
+- BiometricDevice exposes root `site_id` as read-only commissioned device identity
 - ZKTeco-specific options are isolated in ZKTecoOptions or ZKTecoDevice defaults
 - Existing runtime behaviour remains unchanged
 

--- a/docs/specifications/biometric-device.md
+++ b/docs/specifications/biometric-device.md
@@ -23,7 +23,8 @@ The project uses the term:
 
     BiometricDevice
 
-for the runtime-facing abstraction.
+for the runtime-facing abstraction. A `BiometricDevice` represents a
+commissioned biometric terminal deployed at a known office site.
 
 Concrete implementations represent vendor-specific biometric devices.
 
@@ -51,6 +52,7 @@ Concrete biometric device implementations live alongside the abstraction in the 
 This specification covers:
 
 - the runtime-facing biometric device abstraction
+- commissioned device runtime identity
 - biometric device access responsibilities
 - dependency rules for biometric devices
 - audit requirements before finalising the interface
@@ -91,6 +93,10 @@ The audit result should determine the minimal public interface.
 
 Only operations required by current runtime behaviour should appear on the abstraction.
 
+Every `BiometricDevice` instance owns read-only `site_id` runtime identity. The
+value originates from `BiometricDeviceConfig.site_id` and is provided during
+construction by the composition boundary.
+
 ## Non-Responsibilities
 
 `BiometricDevice` does not own:
@@ -130,10 +136,15 @@ The interface should remain minimal.
 
 The current audited interface is:
 
+- `site_id`
+- `extract_attendance_records(from_date, to_date=None)`
 - `pull_records()`
 - `clear_records()`
 
 Additional methods require justification through demonstrated runtime usage.
+
+`extract_attendance_records(...)` must not accept `site_id` as a parameter. The
+device already owns the site identity for the commissioned terminal.
 
 ## Raw Data Boundary
 
@@ -149,6 +160,7 @@ Tests should verify:
 
 - the abstraction exists
 - the abstraction can be imported without vendor SDK dependencies
+- the abstraction exposes read-only `site_id`
 - runtime-facing code can type against the abstraction
 - no concrete biometric device implementation is required to import the abstraction
 - the abstraction does not introduce transformation responsibilities
@@ -189,6 +201,7 @@ The abstraction is complete when:
 
 - `BiometricDevice` exists
 - the interface is minimal
+- `site_id` is read-only runtime identity provided at construction time
 - each method is justified by current usage
 - the abstraction is free of vendor SDK imports
 - transformation concerns are excluded

--- a/docs/specifications/device-factory.md
+++ b/docs/specifications/device-factory.md
@@ -86,6 +86,7 @@ BiometricDeviceFactory owns:
 
 - selecting the concrete biometric device implementation
 - constructing concrete biometric device instances
+- passing root `BiometricDeviceConfig.site_id` into commissioned device instances
 - returning instances as BiometricDevice
 
 BiometricDeviceFactory does not own:
@@ -131,6 +132,10 @@ The factory consumes a validated `BiometricDeviceConfig`.
 `site_id` identifies the office, site, or location from which attendance records
 are extracted. It is deployment/domain metadata and does not belong inside
 `VendorOptions` or `ZKTecoOptions`.
+
+The factory passes `BiometricDeviceConfig.site_id` into the concrete
+`BiometricDevice` during construction. The constructed device then exposes
+`site_id` as read-only runtime identity.
 
 `vendor` selects the biometric device implementation.
 
@@ -203,6 +208,9 @@ The factory should return the abstraction rather than a concrete implementation 
 The exact constructor parameters should be derived from the validated
 `BiometricDeviceConfig` and its `device_options`.
 
+For ZKTeco, the factory passes root `site_id` separately from `ZKTecoOptions`.
+`site_id` must not be folded into vendor options.
+
 The factory should remain simple and explicit.
 
 Do not introduce additional abstraction layers.
@@ -251,6 +259,7 @@ ETLP-27 tests should verify:
 - unsupported vendor selections fail clearly
 - runtime no longer imports or constructs ZKTecoDevice directly
 - factory consumes BiometricDeviceConfig rather than raw ZKTeco fields
+- factory passes BiometricDeviceConfig.site_id into the returned BiometricDevice
 - configuration loading and validation are tested outside the factory boundary
 - site_id remains root-level BiometricDeviceConfig metadata and is not passed as
   a ZKTeco connection option
@@ -342,6 +351,7 @@ ETLP-27 is complete when:
 - unsupported vendors fail clearly
 - root biometric device configuration remains vendor-neutral
 - site_id remains root-level deployment/domain metadata
+- constructed BiometricDevice instances expose read-only site_id
 - ZKTeco-specific options do not live in global ingestion-client configuration
 - configuration loading is separate from concrete device construction
 - existing runtime behaviour remains unchanged

--- a/docs/specifications/zkteco-device.md
+++ b/docs/specifications/zkteco-device.md
@@ -13,6 +13,8 @@ This specification exists to ensure that ZKTeco-specific SDK interaction remains
 The project uses the term BiometricDevice for the runtime-facing abstraction and concrete biometric device names for vendor-specific implementations.
 
 Therefore, ZKTecoDevice represents the concrete implementation while BiometricDevice remains the abstraction consumed by higher-level orchestration code.
+As a BiometricDevice, each ZKTecoDevice instance represents a commissioned
+terminal deployed at a known office site.
 
 ## Related Documents
 
@@ -97,6 +99,7 @@ Concrete device implementations satisfy that contract.
 ZKTecoDevice owns:
 
 - ZKTeco SDK imports
+- read-only commissioned device `site_id` inherited from BiometricDevice
 - device connection lifecycle
 - device communication
 - ZKTeco-specific connection defaults
@@ -144,6 +147,12 @@ They must not live in global ingestion-client configuration.
 deployment/domain metadata identifying the office, site, or location from which
 attendance records are extracted. It is independent of the ZKTeco communication
 mechanism.
+
+`BiometricDeviceFactory` passes `BiometricDeviceConfig.site_id` into
+`ZKTecoDevice` construction. `ZKTecoDevice` inherits the read-only `site_id`
+property from `BiometricDevice` and uses that identity when decoding extracted
+attendance records. Its public `extract_attendance_records(...)` method must
+not require `site_id` as a parameter.
 
 The ZKTeco-specific options are:
 
@@ -224,6 +233,7 @@ This improves encapsulation and keeps device-specific behaviour local to the con
 ETLP-26 tests should verify:
 
 - ZKTecoDevice satisfies BiometricDevice
+- ZKTecoDevice inherits read-only site_id from BiometricDevice
 - SDK interaction remains isolated
 - existing extraction behaviour remains unchanged
 - existing record-clearing behaviour remains unchanged
@@ -280,6 +290,7 @@ Those concerns belong to later issues.
 ETLP-26 is complete when:
 
 - ZKTecoDevice conforms to BiometricDevice
+- ZKTecoDevice receives site_id at construction and inherits the site_id property
 - `BiometricDevice` lives in `attendance_etl.devices.biometric_device`
 - `ZKTecoDevice` lives in `attendance_etl.devices.zkteco_device`
 - no new code imports from the old `attendance_etl.device.base` path

--- a/src/attendance_etl/devices/biometric_device.py
+++ b/src/attendance_etl/devices/biometric_device.py
@@ -1,16 +1,35 @@
 """Project-owned biometric device access contracts."""
 
-from typing import Any, Protocol, Sequence, Tuple, runtime_checkable
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Any, Mapping, Optional, Sequence, Tuple
 
 
-@runtime_checkable
-class BiometricDevice(Protocol):
-    """Runtime-facing contract for biometric device access."""
+class BiometricDevice(ABC):
+    """Runtime-facing contract for a commissioned biometric terminal."""
 
+    def __init__(self, site_id: str):
+        if not isinstance(site_id, str) or not site_id:
+            raise ValueError("site_id must be a non-empty string")
+        self._site_id = site_id
+
+    @property
+    def site_id(self) -> str:
+        """Office site identity for this commissioned device."""
+        return self._site_id
+
+    @abstractmethod
+    def extract_attendance_records(
+        self,
+        from_date: datetime,
+        to_date: Optional[datetime] = None,
+    ) -> Sequence[Mapping[str, Any]]:
+        """Return attendance records extracted for a review window."""
+
+    @abstractmethod
     def pull_records(self) -> Tuple[Sequence[Any], Sequence[Any]]:
         """Return raw device users and raw attendance records."""
-        ...
 
+    @abstractmethod
     def clear_records(self) -> None:
         """Clear attendance records from the device."""
-        ...

--- a/src/attendance_etl/devices/biometric_device_factory.py
+++ b/src/attendance_etl/devices/biometric_device_factory.py
@@ -14,6 +14,6 @@ class BiometricDeviceFactory:
         if device_config.vendor == ZKTECO_VENDOR:
             if not isinstance(device_config.device_options, ZKTecoOptions):
                 raise ValueError("Invalid ZKTeco device options")
-            return ZKTecoDevice(device_config.device_options)
+            return ZKTecoDevice(device_config.site_id, device_config.device_options)
 
         raise ValueError("Unsupported device vendor: {}".format(device_config.vendor))

--- a/src/attendance_etl/devices/zkteco_device.py
+++ b/src/attendance_etl/devices/zkteco_device.py
@@ -1,9 +1,12 @@
-from typing import Any, Sequence, Tuple
+from datetime import datetime
+from typing import Any, Mapping, Optional, Sequence, Tuple
 
 from zk import ZK
 
+from attendance_etl.devices.biometric_device import BiometricDevice
 from attendance_etl.devices.biometric_device_config import ZKTecoOptions
 from attendance_etl.logging_utils import get_logger
+from attendance_etl.transform.zkteco_records import convert_to_map, decode_zk_format, filter_records
 
 logger = get_logger("ZKTecoDevice")
 
@@ -12,8 +15,9 @@ DEFAULT_FORCE_UDP = False
 DEFAULT_OMMIT_PING = False
 
 
-class ZKTecoDevice:
-    def __init__(self, options: ZKTecoOptions):
+class ZKTecoDevice(BiometricDevice):
+    def __init__(self, site_id: str, options: ZKTecoOptions):
+        super().__init__(site_id)
         self.device_ip = options.ip_address
         self.comm_port = options.comm_port
         self.timeout = DEFAULT_TIMEOUT if options.timeout is None else options.timeout
@@ -22,6 +26,25 @@ class ZKTecoDevice:
 
     def clear_records(self) -> None:
         self._clear_records_from_device()
+
+    def extract_attendance_records(
+        self,
+        from_date: datetime,
+        to_date: Optional[datetime] = None,
+    ) -> Sequence[Mapping[str, Any]]:
+        logger.debug("extract_attendance_records invoked")
+        logger.info("fetching data from site %s", self.site_id)
+        users, records = self.pull_records()
+        logger.info("filtering attendance records since %s", from_date.strftime("%d-%m-%Y %H:%M:%S"))
+        unsaved_records = filter_records(records, from_date, to_date)
+        logger.info("%s unsaved attendance records found", len(unsaved_records))
+        user_mapping = convert_to_map(users)
+        logger.debug("decoding unsaved records from zkteco format...")
+        decoded_records = decode_zk_format(unsaved_records, user_mapping, self.site_id)
+
+        logger.info("%s attendance records decoded", len(decoded_records))
+
+        return decoded_records
 
     def pull_records(self) -> Tuple[Sequence[Any], Sequence[Any]]:
         return self._pull_records_from_device()
@@ -66,11 +89,10 @@ class ZKTecoDevice:
         the attendance records stored on the machine
         """
         conn = None
+        users = []
+        records = []
         zk = self._zk_client()
         try:
-            users = []
-            records = []
-
             logger.info("Connecting to device ...")
             conn = zk.connect()
             logger.info("Disabling device ...")
@@ -90,4 +112,4 @@ class ZKTecoDevice:
             if conn:
                 conn.disconnect()
 
-            return users, records
+        return users, records

--- a/src/attendance_etl/pi4/workflow.py
+++ b/src/attendance_etl/pi4/workflow.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, cast
 
 from attendance_etl import config
+from attendance_etl.devices.biometric_device import BiometricDevice
 from attendance_etl.logging_utils import get_logger
 from attendance_etl.models import ReviewPeriod, RuntimeState
 from attendance_etl.pi4.state import (
@@ -20,13 +21,12 @@ from attendance_etl.pi4.state import (
 )
 from attendance_etl.storage.review_period import save_review_period
 from attendance_etl.storage.snapshot import save_snapshot
-from attendance_etl.transform.zkteco_records import convert_to_map, decode_zk_format, filter_records
 
 logger = get_logger("Pi4Workflow")
 
 
 class Pi4Workflow:
-    def __init__(self, state, device, messenger):
+    def __init__(self, state, device: BiometricDevice, messenger):
         self.state = state
         self.device = device
         self.messenger = messenger
@@ -54,29 +54,6 @@ class Pi4Workflow:
     def review_period_info(self):
         return cast(Dict[str, Any], self.state.review_period_info)
 
-    def get_attendance_records(self, from_date, to_date=None):
-        """
-        pulls all attendance records from the biometric device, filters out the
-        records based on the from_date and to_date time frame, and decodes the
-        filtered records from the zkteco format before returning them
-        """
-        logger.debug("get_attendance_records invoked")
-
-        device_info = self.device_info()
-        site_id = device_info["site_id"]
-        logger.info("fetching data from site %s", site_id)
-        users, records = self.device.pull_records()
-        logger.info("filtering attendance records since %s", from_date.strftime("%d-%m-%Y %H:%M:%S"))
-        unsaved_records = filter_records(records, from_date, to_date)
-        logger.info("%s unsaved attendance records found", len(unsaved_records))
-        user_mapping = convert_to_map(users)
-        logger.debug("decoding unsaved records from zkteco format...")
-        decoded_records = decode_zk_format(unsaved_records, user_mapping, site_id)
-
-        logger.info("%s attendance records decoded", len(decoded_records))
-
-        return decoded_records
-
     def review_period_expired(self):
         """
         returns True if the date of the system clock is greater than
@@ -93,7 +70,7 @@ class Pi4Workflow:
     def wait_duration_before_next_pull(self):
         """
         returns the time duration to wait for before attempting to pull
-        the attendance records (from the zkteco device) the next time
+        the attendance records from the biometric device the next time
         """
         review_period_info = self.review_period_info()
         now = datetime.today()
@@ -232,8 +209,7 @@ class Pi4Workflow:
         """
         executes the logic for handling the RELAY_ATTENDANCE_RECORDS state
         """
-        # wait for wait_duration before attempting to pull the attendance records
-        # from the zkteco biometric device
+        # make an attempt to pull the attendance records from the biometric device after wait_duration
         wait_duration = self.wait_duration_before_next_pull()
         time.sleep(wait_duration.total_seconds())
 
@@ -247,7 +223,7 @@ class Pi4Workflow:
             from_timestamp = datetime.strptime(self.state.last_stored_timestamp, "%d-%m-%Y %H:%M:%S")
         else:
             from_timestamp = datetime.strptime(review_period_info["start_date"], "%m/%d/%Y")
-        new_records = self.get_attendance_records(from_timestamp)
+        new_records = self.device.extract_attendance_records(from_timestamp)
 
         if len(new_records) > 0:
             # new (unsaved) attendance records are available on the device since
@@ -272,8 +248,7 @@ class Pi4Workflow:
         self.state.last_stored_timestamp = last_stored_record["timestamp"]
 
         if self.review_period_expired():
-            # proceed with the clean up and maintenance because the review period
-            # has expired
+            # proceed with the clean up and maintenance because the review period has expired
             next_state = REVIEW_PERIOD_EXPIRED
         else:
             next_state = RELAY_ATTENDANCE_RECORDS
@@ -286,14 +261,13 @@ class Pi4Workflow:
         """
         review_period_info = self.review_period_info()
 
-        # check for any unsaved attendance records before attempting to delete
-        # data from the zkteco biometric device
+        # check for any unsaved attendance records before attempting to delete data from the biometric device
         if self.state.last_stored_timestamp is not None:
             from_timestamp = datetime.strptime(self.state.last_stored_timestamp, "%d-%m-%Y %H:%M:%S")
         else:
             from_timestamp = datetime.strptime(review_period_info["start_date"], "%m/%d/%Y")
 
-        new_records = self.get_attendance_records(from_timestamp)
+        new_records = self.device.extract_attendance_records(from_timestamp)
         if len(new_records) == 0:
             # there are no unsaved attendance records on the biometric device,
             # therefore, it is safe to delete all attendance data from the device

--- a/tests/unit/ingestion/test_biometric_device.py
+++ b/tests/unit/ingestion/test_biometric_device.py
@@ -1,19 +1,22 @@
 import ast
 import inspect
 import unittest
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Sequence, Tuple
+from typing import Any, Mapping, Optional, Sequence, Tuple
 
 from attendance_etl.devices.biometric_device import BiometricDevice
-from attendance_etl.devices.biometric_device_config import ZKTecoOptions
-from attendance_etl.devices.zkteco_device import ZKTecoDevice
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-class GenericDevice:
-    def __init__(self):
+class DummyBiometricDevice(BiometricDevice):
+    def __init__(self, site_id="munich-office"):
+        super().__init__(site_id)
         self.cleared = False
+
+    def extract_attendance_records(self, from_date, to_date=None):
+        return [{"device": self.site_id, "timestamp": from_date, "to_date": to_date}]
 
     def pull_records(self):
         return ["user-1"], ["record-1"]
@@ -61,10 +64,22 @@ class BiometricDeviceTests(unittest.TestCase):
             name for name, value in vars(BiometricDevice).items() if callable(value) and not name.startswith("_")
         }
 
-        self.assertEqual(public_methods, {"pull_records", "clear_records"})
+        self.assertEqual(public_methods, {"extract_attendance_records", "pull_records", "clear_records"})
 
+        extract_signature = inspect.signature(BiometricDevice.extract_attendance_records)
         pull_records_signature = inspect.signature(BiometricDevice.pull_records)
         clear_records_signature = inspect.signature(BiometricDevice.clear_records)
+        self.assertEqual(
+            list(extract_signature.parameters),
+            ["self", "from_date", "to_date"],
+        )
+        self.assertEqual(extract_signature.parameters["from_date"].annotation, datetime)
+        self.assertEqual(extract_signature.parameters["to_date"].annotation, Optional[datetime])
+        self.assertIsNone(extract_signature.parameters["to_date"].default)
+        self.assertEqual(
+            extract_signature.return_annotation,
+            Sequence[Mapping[str, Any]],
+        )
         self.assertEqual(list(pull_records_signature.parameters), ["self"])
         self.assertEqual(
             pull_records_signature.return_annotation,
@@ -73,40 +88,32 @@ class BiometricDeviceTests(unittest.TestCase):
         self.assertEqual(list(clear_records_signature.parameters), ["self"])
         self.assertIs(clear_records_signature.return_annotation, None)
 
+    def test_biometric_device_site_id_is_constructor_injected_and_read_only(self):
+        device = DummyBiometricDevice("berlin-office")
+
+        self.assertEqual(device.site_id, "berlin-office")
+        with self.assertRaises(AttributeError):
+            device.site_id = "munich-office"
+
+    def test_biometric_device_rejects_invalid_site_id(self):
+        with self.assertRaisesRegex(ValueError, "^site_id must be a non-empty string$"):
+            DummyBiometricDevice("")
+
     def test_biometric_device_can_type_non_zkteco_implementation(self):
-        device = GenericDevice()
+        device = DummyBiometricDevice()
 
         typed_device: BiometricDevice = device
+        extracted_records = typed_device.extract_attendance_records(datetime(2026, 5, 27, 8, 0, 0))
         users, records = typed_device.pull_records()
         typed_device.clear_records()
 
+        self.assertEqual(
+            extracted_records,
+            [{"device": "munich-office", "timestamp": datetime(2026, 5, 27, 8, 0, 0), "to_date": None}],
+        )
         self.assertEqual(users, ["user-1"])
         self.assertEqual(records, ["record-1"])
         self.assertTrue(device.cleared)
-
-    def test_zkteco_device_satisfies_biometric_device(self):
-        device = ZKTecoDevice(
-            ZKTecoOptions(
-                ip_address="192.0.2.10",
-                comm_port=4370,
-            )
-        )
-
-        typed_device: BiometricDevice = device
-
-        self.assertIs(typed_device, device)
-        self.assertIsInstance(device, BiometricDevice)
-
-    def test_zkteco_device_public_adapter_api_is_minimal(self):
-        public_methods = {
-            name for name, value in vars(ZKTecoDevice).items() if callable(value) and not name.startswith("_")
-        }
-
-        self.assertEqual(public_methods, {"pull_records", "clear_records"})
-        self.assertEqual(list(inspect.signature(ZKTecoDevice.pull_records).parameters), ["self"])
-        self.assertEqual(list(inspect.signature(ZKTecoDevice.clear_records).parameters), ["self"])
-        self.assertFalse(hasattr(ZKTecoDevice, "connect"))
-        self.assertFalse(hasattr(ZKTecoDevice, "disconnect"))
 
     def test_runtime_and_tests_do_not_import_old_device_paths(self):
         paths = [REPO_ROOT / "src/attendance_etl/pi4/runtime.py"]

--- a/tests/unit/ingestion/test_biometric_device_factory.py
+++ b/tests/unit/ingestion/test_biometric_device_factory.py
@@ -71,9 +71,9 @@ class BiometricDeviceFactoryTests(unittest.TestCase):
         device = BiometricDeviceFactory.create(self.zkteco_config())
 
         self.assertIsInstance(device, ZKTecoDevice)
+        self.assertEqual(device.site_id, "munich-office")
         self.assertEqual(device.device_ip, "192.0.2.10")
         self.assertEqual(device.comm_port, 4370)
-        self.assertFalse(hasattr(device, "site_id"))
         self.assertFalse(hasattr(device, "identifier"))
 
     def test_unsupported_vendor_fails_clearly(self):

--- a/tests/unit/ingestion/test_config.py
+++ b/tests/unit/ingestion/test_config.py
@@ -2,8 +2,6 @@ import unittest
 from datetime import timedelta
 
 from attendance_etl import config
-from attendance_etl.devices.biometric_device_config import ZKTecoOptions
-from attendance_etl.devices import zkteco_device
 from attendance_etl.messaging.pubsub import PubSubMessenger
 from attendance_etl.pi4 import runtime
 from attendance_etl.pi4.state import FETCH_REVIEW_PERIOD, Pi4RuntimeState
@@ -20,44 +18,6 @@ class MessengerSpy:
 
     def publish_message_to_topic(self, topic_name, data):
         self.published.append((topic_name, data))
-
-
-class FakeConnection:
-    def disable_device(self):
-        pass
-
-    def enable_device(self):
-        pass
-
-    def get_firmware_version(self):
-        return "fake"
-
-    def get_users(self):
-        return []
-
-    def get_attendance(self):
-        return []
-
-    def clear_attendance(self):
-        pass
-
-    def disconnect(self):
-        pass
-
-
-class FakeZK:
-    instances = []
-
-    def __init__(self, device_ip, port, timeout, force_udp, ommit_ping):
-        self.device_ip = device_ip
-        self.port = port
-        self.timeout = timeout
-        self.force_udp = force_udp
-        self.ommit_ping = ommit_ping
-        FakeZK.instances.append(self)
-
-    def connect(self):
-        return FakeConnection()
 
 
 class ConfigTests(unittest.TestCase):
@@ -111,28 +71,6 @@ class ConfigTests(unittest.TestCase):
                 (config.CREATE_REVIEW_SHEET_TOPIC, {"month": "May"}),
             ],
         )
-
-    def test_zkteco_connection_uses_configured_defaults(self):
-        original_zk = zkteco_device.ZK
-        FakeZK.instances = []
-        zkteco_device.ZK = FakeZK
-        try:
-            zkteco_device.ZKTecoDevice(
-                ZKTecoOptions(
-                    ip_address="192.0.2.10",
-                    comm_port=4370,
-                )
-            ).pull_records()
-        finally:
-            zkteco_device.ZK = original_zk
-
-        self.assertEqual(len(FakeZK.instances), 1)
-        instance = FakeZK.instances[0]
-        self.assertEqual(instance.device_ip, "192.0.2.10")
-        self.assertEqual(instance.port, 4370)
-        self.assertEqual(instance.timeout, zkteco_device.DEFAULT_TIMEOUT)
-        self.assertEqual(instance.force_udp, zkteco_device.DEFAULT_FORCE_UDP)
-        self.assertEqual(instance.ommit_ping, zkteco_device.DEFAULT_OMMIT_PING)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ingestion/test_pi4_workflow.py
+++ b/tests/unit/ingestion/test_pi4_workflow.py
@@ -1,14 +1,46 @@
+import ast
 import unittest
+from datetime import datetime
+from pathlib import Path
 
 import attendance_etl.pi4.workflow as workflow_module
 from attendance_etl.models import RuntimeState
 from attendance_etl.pi4.state import (
+    AWAIT_LAST_STORED_TIMESTAMP,
     AWAIT_REVIEW_PERIOD,
     FETCH_REVIEW_PERIOD,
     FINAL_ALARM_RAISED,
     Pi4RuntimeState,
 )
 from attendance_etl.pi4.workflow import Pi4Workflow
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / "src/attendance_etl/pi4/workflow.py"
+
+
+def imported_modules(path):
+    module_names = set()
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            module_names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            module_names.add(node.module)
+            module_names.update("{}.".format(node.module) + alias.name for alias in node.names)
+
+    return module_names
+
+
+def calls_named(path, name):
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == name:
+                return True
+            if isinstance(node.func, ast.Attribute) and node.func.attr == name:
+                return True
+
+    return False
 
 
 class SnapshotSpy:
@@ -46,14 +78,41 @@ class DeviceStub:
     pass
 
 
+class DeviceExtractionSpy:
+    def __init__(self, records):
+        self.records = records
+        self.extract_calls = []
+        self.clear_calls = 0
+
+    def extract_attendance_records(self, from_date, to_date=None):
+        self.extract_calls.append((from_date, to_date))
+        return self.records
+
+    def pull_records(self):
+        raise AssertionError("workflow must not pull raw biometric records")
+
+    def clear_records(self):
+        self.clear_calls += 1
+
+
+class MessengerPublishSpy:
+    def __init__(self):
+        self.published = []
+
+    def publish_message_to_topic(self, topic_name, data):
+        self.published.append((topic_name, data))
+
+
 class Pi4WorkflowTests(unittest.TestCase):
     def setUp(self):
         self.original_save_snapshot = workflow_module.save_snapshot
         self.original_save_review_period = workflow_module.save_review_period
+        self.original_sleep = workflow_module.time.sleep
 
     def tearDown(self):
         workflow_module.save_snapshot = self.original_save_snapshot
         workflow_module.save_review_period = self.original_save_review_period
+        workflow_module.time.sleep = self.original_sleep
 
     def make_workflow(self, state=None, messenger=None):
         return Pi4Workflow(
@@ -110,6 +169,79 @@ class Pi4WorkflowTests(unittest.TestCase):
         self.assertEqual(review_period_saver.saved, [])
         self.assertIsInstance(snapshot_saver.saves[0], RuntimeState)
         self.assertEqual(snapshot_saver.saves[0].pi4_state, FETCH_REVIEW_PERIOD)
+
+    def test_relay_attendance_records_delegates_extraction_through_biometric_device(self):
+        workflow_module.time.sleep = lambda seconds: None
+        snapshot_saver = SnapshotSpy()
+        workflow_module.save_snapshot = snapshot_saver.save
+        record = {"username": "Ada", "timestamp": "27-05-2026 08:05:00", "entry": "Check In", "device": "munich-office"}
+        device = DeviceExtractionSpy([record])
+        messenger = MessengerPublishSpy()
+        state = Pi4RuntimeState(
+            pi4_state=FETCH_REVIEW_PERIOD,
+            device_info={"site_id": "munich-office"},
+            review_sheet_id="sheet-123",
+        )
+        state.review_period_info = {"start_date": "05/27/2026", "end_date": "12/31/2099"}
+        workflow = Pi4Workflow(state, device, messenger)
+
+        workflow.handler_relay_attendance_records()
+
+        self.assertEqual(
+            device.extract_calls,
+            [(datetime(2026, 5, 27), None)],
+        )
+        self.assertEqual(
+            messenger.published,
+            [
+                (
+                    workflow_module.config.STORE_ATTEND_RECORDS_TOPIC,
+                    {
+                        "sheet_id": "sheet-123",
+                        "device_id": "munich-office",
+                        "start_date": "05/27/2026",
+                        "records": [record],
+                    },
+                )
+            ],
+        )
+        self.assertEqual(state.pi4_state, AWAIT_LAST_STORED_TIMESTAMP)
+        self.assertEqual(snapshot_saver.saves, [])
+
+    def test_review_period_expiry_delegates_extraction_before_clearing_device_records(self):
+        snapshot_saver = SnapshotSpy()
+        workflow_module.save_snapshot = snapshot_saver.save
+        device = DeviceExtractionSpy([])
+        state = Pi4RuntimeState(
+            pi4_state=FETCH_REVIEW_PERIOD,
+            device_info={"site_id": "munich-office"},
+        )
+        state.review_period_info = {"start_date": "05/27/2026", "end_date": "05/29/2026"}
+        workflow = Pi4Workflow(state, device, MessengerStub({}))
+
+        workflow.handler_review_period_expired()
+
+        self.assertEqual(
+            device.extract_calls,
+            [(datetime(2026, 5, 27), None)],
+        )
+        self.assertEqual(device.clear_calls, 1)
+        self.assertIsNone(state.review_sheet_id)
+        self.assertIsNone(state.last_stored_timestamp)
+        self.assertEqual(state.pi4_state, FETCH_REVIEW_PERIOD)
+
+    def test_workflow_has_no_raw_zkteco_extraction_sequence(self):
+        imported = imported_modules(WORKFLOW_PATH)
+
+        self.assertNotIn("attendance_etl.transform.zkteco_records", imported)
+        self.assertNotIn("attendance_etl.transform.zkteco_records.convert_to_map", imported)
+        self.assertNotIn("attendance_etl.transform.zkteco_records.decode_zk_format", imported)
+        self.assertNotIn("attendance_etl.transform.zkteco_records.filter_records", imported)
+        self.assertFalse(calls_named(WORKFLOW_PATH, "pull_records"))
+        self.assertFalse(calls_named(WORKFLOW_PATH, "convert_to_map"))
+        self.assertFalse(calls_named(WORKFLOW_PATH, "decode_zk_format"))
+        self.assertFalse(calls_named(WORKFLOW_PATH, "filter_records"))
+        self.assertTrue(calls_named(WORKFLOW_PATH, "extract_attendance_records"))
 
 
 if __name__ == "__main__":

--- a/tests/unit/ingestion/test_zkteco_device.py
+++ b/tests/unit/ingestion/test_zkteco_device.py
@@ -1,7 +1,23 @@
+import inspect
 import unittest
+from datetime import datetime
 
+from attendance_etl.devices.biometric_device import BiometricDevice
 from attendance_etl.devices.biometric_device_config import ZKTecoOptions
 from attendance_etl.devices import zkteco_device
+
+
+class FakeUser:
+    def __init__(self, user_id, name):
+        self.user_id = user_id
+        self.name = name
+
+
+class FakeAttendanceRecord:
+    def __init__(self, user_id, timestamp, punch):
+        self.user_id = user_id
+        self.timestamp = timestamp
+        self.punch = punch
 
 
 class ConnectionSpy:
@@ -20,11 +36,11 @@ class ConnectionSpy:
 
     def get_users(self):
         self.events.append("get_users")
-        return ["user-1"]
+        return list(ZKSpy.users)
 
     def get_attendance(self):
         self.events.append("get_attendance")
-        return ["record-1"]
+        return list(ZKSpy.records)
 
     def clear_attendance(self):
         self.events.append("clear_attendance")
@@ -36,6 +52,8 @@ class ConnectionSpy:
 class ZKSpy:
     events = []
     instances = []
+    users = ["user-1"]
+    records = ["record-1"]
 
     def __init__(self, device_ip, port, timeout, force_udp, ommit_ping):
         self.device_ip = device_ip
@@ -57,6 +75,8 @@ class ZKTecoDeviceTests(unittest.TestCase):
         zkteco_device.ZK = ZKSpy
         ZKSpy.events = []
         ZKSpy.instances = []
+        ZKSpy.users = ["user-1"]
+        ZKSpy.records = ["record-1"]
 
     def tearDown(self):
         zkteco_device.ZK = self.original_zk
@@ -69,8 +89,42 @@ class ZKTecoDeviceTests(unittest.TestCase):
         values.update(overrides)
         return ZKTecoOptions(**values)
 
+    def test_zkteco_device_satisfies_biometric_device(self):
+        device = zkteco_device.ZKTecoDevice("munich-office", self.zkteco_options())
+
+        typed_device: BiometricDevice = device
+
+        self.assertIs(typed_device, device)
+        self.assertIsInstance(device, BiometricDevice)
+        self.assertEqual(device.site_id, "munich-office")
+
+    def test_zkteco_device_inherits_read_only_site_id_from_biometric_device(self):
+        device = zkteco_device.ZKTecoDevice("munich-office", self.zkteco_options())
+
+        self.assertIs(zkteco_device.ZKTecoDevice.site_id, BiometricDevice.site_id)
+        self.assertEqual(device.site_id, "munich-office")
+        with self.assertRaises(AttributeError):
+            device.site_id = "berlin-office"
+
+    def test_zkteco_device_public_adapter_api_is_minimal(self):
+        public_methods = {
+            name
+            for name, value in vars(zkteco_device.ZKTecoDevice).items()
+            if callable(value) and not name.startswith("_")
+        }
+
+        self.assertEqual(public_methods, {"extract_attendance_records", "pull_records", "clear_records"})
+        self.assertEqual(
+            list(inspect.signature(zkteco_device.ZKTecoDevice.extract_attendance_records).parameters),
+            ["self", "from_date", "to_date"],
+        )
+        self.assertEqual(list(inspect.signature(zkteco_device.ZKTecoDevice.pull_records).parameters), ["self"])
+        self.assertEqual(list(inspect.signature(zkteco_device.ZKTecoDevice.clear_records).parameters), ["self"])
+        self.assertFalse(hasattr(zkteco_device.ZKTecoDevice, "connect"))
+        self.assertFalse(hasattr(zkteco_device.ZKTecoDevice, "disconnect"))
+
     def test_pull_records_preserves_connection_lifecycle(self):
-        users, records = zkteco_device.ZKTecoDevice(self.zkteco_options()).pull_records()
+        users, records = zkteco_device.ZKTecoDevice("munich-office", self.zkteco_options()).pull_records()
 
         self.assertEqual(users, ["user-1"])
         self.assertEqual(records, ["record-1"])
@@ -88,8 +142,44 @@ class ZKTecoDeviceTests(unittest.TestCase):
             ],
         )
 
+    def test_extract_attendance_records_owns_zkteco_extraction_sequence(self):
+        ZKSpy.users = [FakeUser(100, "Ada Lovelace")]
+        ZKSpy.records = [
+            FakeAttendanceRecord(100, datetime(2026, 5, 27, 7, 59, 59), 0),
+            FakeAttendanceRecord(100, datetime(2026, 5, 27, 8, 1, 0), 1),
+        ]
+
+        records = zkteco_device.ZKTecoDevice("munich-office", self.zkteco_options()).extract_attendance_records(
+            datetime(2026, 5, 27, 8, 0, 0)
+        )
+
+        self.assertEqual(
+            records,
+            [
+                {
+                    "username": "Ada Lovelace",
+                    "timestamp": "27-05-2026 08:01:00",
+                    "entry": "Check Out",
+                    "device": "munich-office",
+                }
+            ],
+        )
+        self.assertEqual(
+            ZKSpy.events,
+            [
+                "instantiate",
+                "connect",
+                "disable_device",
+                "get_firmware_version",
+                "get_users",
+                "get_attendance",
+                "enable_device",
+                "disconnect",
+            ],
+        )
+
     def test_clear_records_preserves_connection_lifecycle(self):
-        zkteco_device.ZKTecoDevice(self.zkteco_options()).clear_records()
+        zkteco_device.ZKTecoDevice("munich-office", self.zkteco_options()).clear_records()
 
         self.assertEqual(
             ZKSpy.events,
@@ -106,17 +196,29 @@ class ZKTecoDeviceTests(unittest.TestCase):
 
     def test_zkteco_device_uses_explicit_connection_options(self):
         zkteco_device.ZKTecoDevice(
+            "munich-office",
             self.zkteco_options(
                 timeout=15,
                 force_udp=True,
                 ommit_ping=True,
-            )
+            ),
         ).pull_records()
 
         instance = ZKSpy.instances[0]
         self.assertEqual(instance.timeout, 15)
         self.assertIs(instance.force_udp, True)
         self.assertIs(instance.ommit_ping, True)
+
+    def test_zkteco_device_uses_implementation_defaults_for_absent_optional_options(self):
+        zkteco_device.ZKTecoDevice("munich-office", self.zkteco_options()).pull_records()
+
+        self.assertEqual(len(ZKSpy.instances), 1)
+        instance = ZKSpy.instances[0]
+        self.assertEqual(instance.device_ip, "192.0.2.10")
+        self.assertEqual(instance.port, 4370)
+        self.assertEqual(instance.timeout, zkteco_device.DEFAULT_TIMEOUT)
+        self.assertEqual(instance.force_udp, zkteco_device.DEFAULT_FORCE_UDP)
+        self.assertEqual(instance.ommit_ping, zkteco_device.DEFAULT_OMMIT_PING)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
planning_metadata:
  estimated_effort: 1.5h
  priority: High
  milestone: "3. Device Layer Abstraction"
-->

## Summary

Move biometric device extraction orchestration into the device adapter layer so Pi runtime/workflow code depends only on the BiometricDevice abstraction.

## Should have

- Moves raw biometric device communication out of Pi orchestration.
- Keeps ZKTeco-specific extraction behaviour inside ZKTecoDevice.
- Exposes a high-level extraction operation through the BiometricDevice abstraction.
- Preserves the existing ZKTeco extraction behaviour.
- Keeps runtime startup based on BiometricDeviceConfigBuilder and BiometricDeviceFactory.

## Nice to have

- Adds debug logging around adapter-level device operations.
- Keeps log messages vendor-neutral outside the ZKTeco adapter.

## Acceptance criteria

- [x] Pi runtime/workflow no longer contains raw biometric device communication logic.
- [x] Pi runtime/workflow does not directly call ZKTeco-specific operations.
- [x] Device-specific extraction behaviour is isolated in the adapter/device layer.
- [x] ZKTecoDevice owns ZKTeco connection/extraction sequencing.
- [x] Runtime still loads BiometricDeviceConfig before device creation.
- [x] Runtime still creates devices through BiometricDeviceFactory.
- [x] Existing valid ZKTeco extraction flow remains functionally unchanged.
- [x] No canonicalisation, transformation strategy, Pub/Sub schema change, or downstream device_id rename is introduced.

---

## Changes

- Introduces adapter-owned biometric device extraction through the `BiometricDevice` abstraction
- Refactors extraction sequencing into `ZKTecoDevice`
- Converts `BiometricDevice` from a Protocol to an Abstract Base Class
- Introduces constructor-injected, read-only `site_id` on `BiometricDevice`
- Injects `site_id` through `BiometricDeviceFactory` during device construction
- Removes `site_id` from the `extract_attendance_records(...)` API
- Refactors workflow to depend exclusively on the vendor-neutral device contract
- Aligns architecture, ADRs, proposals, and specifications with the commissioned-device identity model
- Adds and updates tests covering extraction delegation, factory injection, and device identity semantics