### PR TITLE
ETLP-29: introduces transformation layer foundation

### DIFF
--- a/docs/proposals/ingestion-modularisation.md
+++ b/docs/proposals/ingestion-modularisation.md
@@ -323,12 +323,12 @@ Milestone:
 
     4. Transformation Layer
 
-Relevant Issues:
+Relevant transformation capabilities:
 
-- Create Transformation Module
-- Implement Canonical Transformer
-- Add Validation Logic
-- Implement Data Normalisation
+- Introduce transformation layer
+- Introduce canonical attendance models
+- Introduce validation pipeline
+- Introduce normalisation pipeline
 
 Reason:
 

--- a/docs/proposals/transformation-layer.md
+++ b/docs/proposals/transformation-layer.md
@@ -285,44 +285,62 @@ Concrete transformation strategies may use temporary lookup structures internall
 
 Such structures remain private implementation details and must not appear in public contracts, workflow APIs, runtime state, or transformation boundaries.
 
-## ETLP-29: Introduce Transformation Layer
+## Phase 1 — Transformation Layer Foundation
+
+Related Issues:
+
+- ETLP-29
 
 ### Scope
 
-Introduce the TransformationStrategy abstraction.
+Introduce the internal transformation-layer foundation.
 
 ### Expected Deliverables
 
+- Employee
+- EventType
+- TransformationRequest
+- ExtractedBiometricData
+- TimeRange
+- NormalisedAttendance
 - TransformationStrategy interface or abstract base class
 - Transformation package structure
 - Documentation of transformation responsibilities
 
 ### Acceptance Criteria
 
+- Internal transformation-layer foundation artifacts are defined
 - Transformation responsibilities are clearly defined
 - Runtime remains unaware of device-specific transformation details
 - No runtime behaviour changes
 
-## ETLP-30: Implement ZKTeco Transformation Strategy
+## Phase 2 — Canonical Domain Models
+
+Related Issues:
+
+- ETLP-30
 
 ### Scope
 
-Implement ZKTecoTransformationStrategy.
+Define the canonical attendance model and external payload contracts produced by transformation.
 
 ### Expected Deliverables
 
-- ZKTecoTransformationStrategy
-- Employee model construction
-- NormalisedAttendance construction
 - AttendanceEvent model construction
+- AttendanceEvent serialisation contract
+- AttendanceEvent Pub/Sub payload contract
 
 ### Acceptance Criteria
 
-- Device-specific records are transformed into NormalisedAttendance
 - Canonical AttendanceEvent objects are produced
+- AttendanceEvent serialisation and Pub/Sub payload contracts are defined
 - Existing behaviour is preserved
 
-## ETLP-31: Implement Validation Pipeline
+## Phase 3 — Transformation Pipeline
+
+Related Issues:
+
+- ETLP-31
 
 ### Scope
 
@@ -342,11 +360,15 @@ Validation of:
 - Invalid data is detected consistently
 - Validation rules are isolated within the transformation layer
 
-## ETLP-32: Implement Normalisation Pipeline
+## Phase 4 — Vendor Integration
+
+Related Issues:
+
+- ETLP-32
 
 ### Scope
 
-Introduce normalisation during transformation.
+Introduce vendor-specific transformation strategy integration.
 
 ### Expected Deliverables
 
@@ -360,24 +382,6 @@ Normalisation of:
 
 - Equivalent data from different vendors produces equivalent domain models
 - Normalisation logic is isolated within the transformation layer
-
-## Implementation Phases
-
-### Phase 1
-
-ETLP-29 — Introduce Transformation Layer
-
-### Phase 2
-
-ETLP-30 — Implement ZKTeco Transformation Strategy
-
-### Phase 3
-
-ETLP-31 — Implement Validation Pipeline
-
-### Phase 4
-
-ETLP-32 — Implement Normalisation Pipeline
 
 ## Acceptance Criteria
 

--- a/src/attendance_etl/models/__init__.py
+++ b/src/attendance_etl/models/__init__.py
@@ -1,6 +1,6 @@
 """Core domain models shared across attendance ETL modules."""
 
-from attendance_etl.models.attendance_event import AttendanceEvent
+from attendance_etl.models.attendance_event import AttendanceEvent, EventType
 from attendance_etl.models.employee import Employee
 from attendance_etl.models.interfaces import IDeserializable, ISerializable
 from attendance_etl.models.review_period import ReviewPeriod
@@ -9,6 +9,7 @@ from attendance_etl.models.runtime_state import RuntimeState
 __all__ = [
     "AttendanceEvent",
     "Employee",
+    "EventType",
     "IDeserializable",
     "ISerializable",
     "ReviewPeriod",

--- a/src/attendance_etl/models/attendance_event.py
+++ b/src/attendance_etl/models/attendance_event.py
@@ -1,8 +1,14 @@
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, Optional
 
 ATTENDANCE_TIMESTAMP_FORMAT = "%d-%m-%Y %H:%M:%S"
+
+
+class EventType(Enum):
+    CLOCK_IN = "CLOCK_IN"
+    CLOCK_OUT = "CLOCK_OUT"
 
 
 def _parse_datetime(value: str) -> datetime:

--- a/src/attendance_etl/models/employee.py
+++ b/src/attendance_etl/models/employee.py
@@ -1,39 +1,18 @@
-from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from attendance_etl.models.interfaces import ISerializable
 
 
-@dataclass
-class Employee:
-    """Minimal employee representation used for source-device user mapping."""
+@dataclass(frozen=True)
+class Employee(ISerializable):
+    """Normalised employee identity used during transformation."""
 
-    employee_id: str
-    name: Optional[str] = None
-    source_device_id: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
-
-    @classmethod
-    def from_zkteco_user(cls, user: Any, source_device_id: Optional[str] = None) -> "Employee":
-        return cls(
-            employee_id=str(user.user_id),
-            name=getattr(user, "name", None),
-            source_device_id=source_device_id,
-        )
+    id: str
+    name: str
 
     def to_dict(self) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {
-            "employee_id": self.employee_id,
+        return {
+            "id": self.id,
             "name": self.name,
-            "source_device_id": self.source_device_id,
         }
-        if self.metadata:
-            payload["metadata"] = dict(self.metadata)
-        return payload
-
-    @classmethod
-    def from_dict(cls, payload: Dict[str, Any]) -> "Employee":
-        return cls(
-            employee_id=payload["employee_id"],
-            name=payload.get("name"),
-            source_device_id=payload.get("source_device_id"),
-            metadata=dict(payload.get("metadata", {})),
-        )

--- a/src/attendance_etl/transform/__init__.py
+++ b/src/attendance_etl/transform/__init__.py
@@ -1,1 +1,11 @@
-"""Source-record transformation helpers."""
+"""Transformation-layer foundation models and source-record helpers."""
+
+from attendance_etl.transform.normalised_attendance import NormalisedAttendance
+from attendance_etl.transform.transformation_request import ExtractedBiometricData, TimeRange, TransformationRequest
+
+__all__ = [
+    "ExtractedBiometricData",
+    "NormalisedAttendance",
+    "TimeRange",
+    "TransformationRequest",
+]

--- a/src/attendance_etl/transform/normalised_attendance.py
+++ b/src/attendance_etl/transform/normalised_attendance.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+from attendance_etl.models import Employee, EventType
+
+
+@dataclass(frozen=True)
+class NormalisedAttendance:
+    """Internal attendance representation used before canonicalisation."""
+
+    employee: Employee
+    punch: EventType
+    timestamp: datetime

--- a/src/attendance_etl/transform/transformation_request.py
+++ b/src/attendance_etl/transform/transformation_request.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class ExtractedBiometricData:
+    """Raw biometric-device data supplied to the transformation layer."""
+
+    employees: Sequence[Any]
+    attendance_records: Sequence[Any]
+
+
+@dataclass(frozen=True)
+class TimeRange:
+    """Filtering boundary for transformation requests."""
+
+    start_time: datetime
+    end_time: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class TransformationRequest:
+    """Grouped inputs for a transformation operation."""
+
+    raw_data: ExtractedBiometricData
+    site_id: str
+    time_range: TimeRange

--- a/src/attendance_etl/transform/zkteco_records.py
+++ b/src/attendance_etl/transform/zkteco_records.py
@@ -13,7 +13,7 @@ def convert_to_map(zk_users):
     logger.debug("Generating user id to name mapping for %s users...", len(zk_users))
     user_mapping = {}
     for zk_user in zk_users:
-        employee = Employee.from_zkteco_user(zk_user)
+        employee = Employee(id=str(zk_user.user_id), name=zk_user.name)
         user_mapping[zk_user.user_id] = employee
 
     return user_mapping

--- a/tests/unit/ingestion/test_models.py
+++ b/tests/unit/ingestion/test_models.py
@@ -1,8 +1,7 @@
 import unittest
 from datetime import datetime
-from types import SimpleNamespace
 
-from attendance_etl.models import AttendanceEvent, Employee, ReviewPeriod, RuntimeState
+from attendance_etl.models import AttendanceEvent, Employee, ISerializable, ReviewPeriod, RuntimeState
 
 
 class DomainModelTests(unittest.TestCase):
@@ -70,15 +69,20 @@ class DomainModelTests(unittest.TestCase):
         self.assertEqual(event.raw_event_type, "Check In")
         self.assertEqual(event.metadata, {"source_format": "zkteco"})
 
-    def test_employee_from_zkteco_user_keeps_minimal_identity(self):
-        employee = Employee.from_zkteco_user(
-            SimpleNamespace(user_id="10042", name="Ayesha Khan"),
-            source_device_id="att-dev-dk-01",
-        )
+    def test_employee_contract_contains_only_normalised_identity(self):
+        employee = Employee(id="10042", name="Ayesha Khan")
 
-        self.assertEqual(employee.employee_id, "10042")
+        self.assertIn(ISerializable, Employee.__mro__)
+        self.assertEqual(employee.id, "10042")
         self.assertEqual(employee.name, "Ayesha Khan")
-        self.assertEqual(employee.source_device_id, "att-dev-dk-01")
+        self.assertEqual(set(employee.__dataclass_fields__), {"id", "name"})
+        self.assertFalse(hasattr(Employee, "from_dict"))
+        self.assertFalse(hasattr(Employee, "from_zkteco_user"))
+
+    def test_employee_to_dict_serializes_normalised_identity(self):
+        employee = Employee(id="10042", name="Ayesha Khan")
+
+        self.assertEqual(employee.to_dict(), {"id": "10042", "name": "Ayesha Khan"})
 
     def test_review_period_round_trip_preserves_legacy_keys_and_metadata(self):
         payload = {

--- a/tests/unit/ingestion/test_transformation_foundation.py
+++ b/tests/unit/ingestion/test_transformation_foundation.py
@@ -1,0 +1,77 @@
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any, get_args, get_origin
+
+from attendance_etl.models import Employee, EventType
+from attendance_etl.transform import ExtractedBiometricData, NormalisedAttendance, TimeRange, TransformationRequest
+
+
+class TransformationFoundationTests(unittest.TestCase):
+    def test_event_type_values_are_vendor_neutral(self):
+        self.assertEqual(EventType.CLOCK_IN.value, "CLOCK_IN")
+        self.assertEqual(EventType.CLOCK_OUT.value, "CLOCK_OUT")
+        self.assertEqual(set(EventType), {EventType.CLOCK_IN, EventType.CLOCK_OUT})
+
+    def test_extracted_biometric_data_structure_groups_raw_device_data(self):
+        employees = [SimpleNamespace(user_id="10042")]
+        attendance_records = [SimpleNamespace(user_id="10042")]
+
+        raw_data = ExtractedBiometricData(employees=employees, attendance_records=attendance_records)
+
+        self.assertEqual(raw_data.employees, employees)
+        self.assertEqual(raw_data.attendance_records, attendance_records)
+        self.assertEqual(set(raw_data.__dataclass_fields__), {"employees", "attendance_records"})
+
+    def test_time_range_structure_defaults_end_time_to_none(self):
+        start_time = datetime(2026, 5, 27, 8, 0, 0)
+
+        time_range = TimeRange(start_time=start_time)
+
+        self.assertEqual(time_range.start_time, start_time)
+        self.assertIsNone(time_range.end_time)
+        self.assertEqual(set(time_range.__dataclass_fields__), {"start_time", "end_time"})
+
+    def test_transformation_request_structure_groups_request_context(self):
+        raw_data = ExtractedBiometricData(employees=[], attendance_records=[])
+        time_range = TimeRange(start_time=datetime(2026, 5, 27, 8, 0, 0))
+
+        request = TransformationRequest(raw_data=raw_data, site_id="dk", time_range=time_range)
+
+        self.assertEqual(request.raw_data, raw_data)
+        self.assertEqual(request.site_id, "dk")
+        self.assertEqual(request.time_range, time_range)
+        self.assertEqual(set(request.__dataclass_fields__), {"raw_data", "site_id", "time_range"})
+
+    def test_normalised_attendance_structure_composes_employee_and_event_type(self):
+        employee = Employee(id="10042", name="Ayesha Khan")
+        timestamp = datetime(2026, 5, 27, 8, 59, 12)
+
+        attendance = NormalisedAttendance(employee=employee, punch=EventType.CLOCK_IN, timestamp=timestamp)
+
+        self.assertEqual(attendance.employee, employee)
+        self.assertEqual(attendance.punch, EventType.CLOCK_IN)
+        self.assertEqual(attendance.timestamp, timestamp)
+        self.assertEqual(set(attendance.__dataclass_fields__), {"employee", "punch", "timestamp"})
+
+        annotations = NormalisedAttendance.__annotations__
+        self.assertIs(annotations["employee"], Employee)
+        self.assertIs(annotations["punch"], EventType)
+        self.assertIs(annotations["timestamp"], datetime)
+
+    def test_transformation_foundation_dataclasses_are_frozen(self):
+        self.assertTrue(ExtractedBiometricData.__dataclass_params__.frozen)
+        self.assertTrue(TimeRange.__dataclass_params__.frozen)
+        self.assertTrue(TransformationRequest.__dataclass_params__.frozen)
+        self.assertTrue(NormalisedAttendance.__dataclass_params__.frozen)
+
+    def test_extracted_data_annotations_accept_raw_sequences(self):
+        annotations = ExtractedBiometricData.__annotations__
+
+        self.assertIs(get_origin(annotations["employees"]), get_origin(annotations["attendance_records"]))
+        self.assertEqual(get_args(annotations["employees"]), (Any,))
+        self.assertEqual(get_args(annotations["attendance_records"]), (Any,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/ingestion/test_zkteco_records.py
+++ b/tests/unit/ingestion/test_zkteco_records.py
@@ -35,9 +35,8 @@ class ZKTecoRecordTransformTests(unittest.TestCase):
 
         self.assertEqual(list(user_mapping), [10042])
         self.assertIsInstance(user_mapping[10042], Employee)
-        self.assertEqual(user_mapping[10042].employee_id, "10042")
+        self.assertEqual(user_mapping[10042].id, "10042")
         self.assertEqual(user_mapping[10042].name, "Ayesha Khan")
-        self.assertIsNone(user_mapping[10042].source_device_id)
 
     def test_convert_to_dict_preserves_external_attendance_payload_shape(self):
         users = [SimpleNamespace(user_id="10042", name="Ayesha Khan")]


### PR DESCRIPTION
## Summary

- Introduces transformation-layer foundation models
- Replaces Employee with the Milestone 4 contract
- Adds EventType with canonical attendance values
- Updates transitional ZKTeco mapping for Employee compatibility
- Adds focused transformation foundation tests

## Should have

- Introduce transformation-layer foundation artefacts within the `src/attendance_etl/transform/` package
- Implement the following internal transformation-layer foundation artefacts:
  - `Employee`
  - `EventType`
  - `TransformationRequest`
  - `ExtractedBiometricData`
  - `TimeRange`
  - `NormalisedAttendance`
- Align model locations with `transformation-strategy.md`


## Nice to have

- Add module-level documentation
- Add type aliases where they improve readability


## Should not have

- Transformation logic
- Validation logic
- Canonicalisation logic
- Runtime integration
- ZKTeco-specific behaviour
- `AttendanceEvent`


## Acceptance criteria

- [x] Transformation package exists
- [x] Employee contains only `id` and `name`
- [x] Employee implements `ISerializable`
- [x] Employee has no `from_dict(...)`, vendor factory, or ZKTeco helper
- [x] EventType contains `CLOCK_IN` and `CLOCK_OUT`
- [x] `TransformationRequest`, `ExtractedBiometricData`, `TimeRange`, and `NormalisedAttendance` match the specification
- [x] `NormalisedAttendance` composes `Employee`
- [x] `NormalisedAttendance.punch` uses `EventType`
- [x] No runtime behaviour is changed
- [x] No SDK communication logic exists inside the transformation package