### PR TITLE
ETLP-30: introduces canonical attendance event

### DIFF
--- a/docs/contracts/canonical-attendance-event.md
+++ b/docs/contracts/canonical-attendance-event.md
@@ -1,137 +1,184 @@
 # Canonical Attendance Event
 
-The canonical attendance event is the normalised internal representation of one attendance event reported by
-a source biometric device. It is produced after extraction and source-specific normalisation, during
-canonicalisation, and is intended for downstream publication, processing, and persistence.
+The canonical attendance event is the normalised internal representation of one
+attendance event reported by a source biometric device. It is produced after
+extraction and source-specific normalisation, during transformation and normalisation, and is
+intended for downstream publication, processing, and persistence.
 
-This contract describes the target canonical payload shape. Current device-specific decoding and publishing
-may still emit transitional fields until transformation work adopts this contract end to end.
+This contract distinguishes the current ETLP-30 internal model from the current
+backend-compatible Pub/Sub payload. ETLP-30 does not introduce a richer canonical
+wire schema.
 
-`attendance_etl.models.AttendanceEvent` is the Python dataclass representation of this contract for internal
-code. Its conversion helpers are available for model/dictionary conversion, but current runtime publishing may
-continue to use transitional dictionaries until canonical adoption is completed separately.
+For pipeline stage sequencing, see [Data Pipeline](../data-pipeline.md). For
+runtime adoption limits, see [Architecture](../architecture.md).
 
-For pipeline stage sequencing, see [Data Pipeline](../data-pipeline.md). For runtime adoption limits, see
-[Architecture](../architecture.md).
+## Current ETLP-30 Internal Model Contract
 
-## Schema
+`attendance_etl.models.AttendanceEvent` is the Python dataclass representation
+of the canonical internal attendance event model.
+
+Expected structure:
+
+```python
+@dataclass(frozen=True)
+class AttendanceEvent:
+    site_id: str
+    employee: Employee
+    event_type: EventType
+    timestamp: datetime
+```
+
+Current model fields:
 
 | field | type | required/optional | description | example |
 | --- | --- | --- | --- | --- |
-| `event_id` | string | required | Canonical event identifier. It should be deterministic when the source guarantees uniqueness; otherwise it is generated during transformation/canonicalisation. | `att-dev-dk-01-10042-2026-05-27T08:59:12Z` |
-| `source_device_id` | string | required | Configured or logical identifier for the biometric device that produced the source record. | `att-dev-dk-01` |
-| `employee_id` | string | required | Employee or device user identifier from the source device. | `10042` |
-| `event_timestamp` | string | required | ISO 8601 timestamp for when the attendance event occurred. | `2026-05-27T08:59:12Z` |
-| `event_type` | string | required | Canonical event type. Supported baseline values are `clock_in`, `clock_out`, and `unknown`. | `clock_in` |
-| `ingested_at` | string | required | ISO 8601 timestamp for when the source record was ingested. | `2026-05-27T09:00:03Z` |
-| `source_record_id` | string | optional | Original source-device record identifier, if the device or extraction layer provides one. | `zk-879221` |
-| `employee_name` | string | optional | Enrichment or display name associated with the employee. | `Ayesha Khan` |
-| `site_id` | string | optional | Logical office or site identifier associated with the source device. | `dk` |
-| `raw_event_type` | string | optional | Original source-device event or status value before canonicalisation. | `Check In` |
-| `metadata` | object | optional | Extension object for implementation-specific fields that should not become top-level contract fields yet. | `{"source_format":"zkteco"}` |
+| `site_id` | string | required | Logical office or site identifier associated with the source device. | `dk` |
+| `employee` | Employee | required | Normalised employee identity composed into the attendance event. | `Employee(id="10042", name="Ayesha Khan")` |
+| `event_type` | EventType | required | Attendance event type used for the current backend-compatible payload. | `EventType.CLOCK_IN` |
+| `timestamp` | datetime | required | Timestamp for when the attendance event occurred. | `datetime(2026, 5, 27, 8, 59, 12)` |
+
+`AttendanceEvent` composes `Employee` rather than duplicating employee attributes
+as flattened fields.
+
+## Current Backend-Compatible Pub/Sub Payload
+
+`AttendanceEvent.to_dict()` intentionally serialises to the Pub/Sub payload
+shape expected by the current backend:
+
+```json
+{
+  "username": "Ayesha Khan",
+  "timestamp": "27-05-2026 08:59:12",
+  "entry": "Check In",
+  "device": "dk"
+}
+```
+
+The serialisation contract is:
+
+```python
+{
+    "username": self.employee.name,
+    "timestamp": self.timestamp.strftime(ATTENDANCE_TIMESTAMP_FORMAT),
+    "entry": self.event_type.value,
+    "device": self.site_id,
+}
+```
+
+Timestamp serialisation currently uses:
+
+```python
+ATTENDANCE_TIMESTAMP_FORMAT = "%d-%m-%Y %H:%M:%S"
+```
+
+Current `EventType` values are intentionally backend-compatible:
+
+```python
+EventType.CLOCK_IN.value == "Check In"
+EventType.CLOCK_OUT.value == "Check Out"
+```
+
+The current wire payload remains transitional/backend-compatible. It must not be
+treated as the final canonical wire schema.
 
 ## Event Semantics
 
-One canonical attendance event represents one attendance interaction extracted from a source biometric
-device after normalisation/canonicalisation. It does not represent a review period, an employee schedule, an aggregate
-attendance day, or a storage update result.
+One canonical attendance event represents one attendance interaction extracted
+from a source biometric device after normalisation/canonicalisation. It does not
+represent a review period, an employee schedule, an aggregate attendance day, or
+a storage update result.
 
-Canonical events are intended to be the stable internal payload passed to publication, backend processing,
-and persistence boundaries. Runtime adoption is still transitional: current ingestion and storage paths may
-publish or consume legacy dictionaries until the transformation layer fully emits this contract.
+The ETLP-30 internal model is canonical for transformation-layer output. The
+current Pub/Sub payload remains shaped for backend compatibility until a
+dedicated contract migration introduces a richer canonical wire payload.
 
-## Field Semantics
+## Deferred Canonical Payload Evolution
 
-### Event Identity
+The following fields and semantics are deferred contract evolution items. They
+are not current ETLP-30 `AttendanceEvent` fields and are not emitted by the
+current ETLP-30 Pub/Sub payload.
 
-`event_id` identifies one canonical attendance event and should be stable and deterministic where possible. If
-the source provides a stable record identifier, that value may contribute to the canonical identity through
-`source_record_id` or the event ID derivation. If the source does not provide a stable record identifier, the
-canonicalisation layer may derive identity from stable source facts such as `source_device_id`, `employee_id`,
-`event_timestamp`, and source metadata.
+### event_id
 
-`event_id` must not depend on transient processing time alone. `ingested_at` can help with observability and
-ordering, but it is not sufficient as the only identity input.
+`event_id` is a future unique canonical event identifier.
 
-### Timestamps
+Current architectural preference is generation at the messaging/publication boundary, while allowing future design work to reassign ownership if required.
 
-`event_timestamp` is the time the attendance punch or source event occurred. `ingested_at` is the time the
-source record entered the pipeline. These fields have different meanings and must not be conflated.
+### ingested_at
 
-### Event Types
+`ingested_at` is a future publication or ingestion timestamp.
 
-`event_type` is the canonical event type used by baseline consumers. The accepted initial values are
-conservative: `clock_in`, `clock_out`, and `unknown`.
+Prefer generation at the messaging/publication boundary.
 
-`raw_event_type` preserves the source-specific status, label, or code before canonicalisation when that value
-is available. Future canonical `event_type` values broaden the contract and should be introduced through the
-schema evolution guidance below.
+### event_timestamp
+
+`event_timestamp` is the future canonical wire-payload name for the attendance
+event timestamp.
+
+The current ETLP-30 payload keeps `"timestamp"` for backend compatibility.
+
+### source_device_id
+
+`source_device_id` is a future canonical `AttendanceEvent` provenance field.
+
+It should be introduced once biometric device identity is available to the
+transformation layer.
+
+source_device_id provides event provenance and enables traceability back to the originating biometric device.
+
+### Timezone-Aware Timestamp Semantics
+
+Future canonical timestamps should preserve timezone information.
+
+Current ETLP-30 serialisation uses `ATTENDANCE_TIMESTAMP_FORMAT` for backend
+compatibility and does not preserve timezone information in the wire payload.
+
+### EventType Wire Values
+
+Current values remain:
+
+```python
+"Check In"
+"Check Out"
+```
+
+Future canonical wire values should migrate toward:
+
+```python
+"Clock In"
+"Clock Out"
+```
+
+Any migration of EventType wire values must be introduced through a dedicated
+contract migration issue.
 
 ## Schema Evolution
 
-- Additive optional fields are the preferred backward-compatible evolution path.
-- New required fields are breaking changes because baseline consumers may not provide or understand them.
-- Renaming or removing fields is breaking and requires explicit migration planning.
-- Broadening canonical enum-like values, including `event_type`, must be documented so consumers can decide
-  whether to reject, ignore, or handle the new value.
-- Consumers should tolerate unknown optional fields where reasonable.
-- `metadata` may carry implementation-specific extensions, but required business semantics should graduate to
-  documented top-level fields instead of remaining hidden inside `metadata`.
-
-## Required And Optional Fields
-
-Required fields define the minimum stable contract for a canonical attendance event. Optional fields enrich
-the event for display, debugging, source traceability, or implementation-specific use, but baseline consumers
-must not require optional fields to process a valid minimal payload.
-
-Promoting an optional field to required is a breaking change. Deprecations should be documented before
-removal, with enough migration guidance for producers and consumers to move away from the deprecated field.
+- The current ETLP-30 model fields are `site_id`, `employee`, `event_type`, and
+  `timestamp`.
+- The current ETLP-30 Pub/Sub payload fields are `username`, `timestamp`,
+  `entry`, and `device`.
+- Deferred canonical wire-payload fields must not be treated as currently
+  implemented fields.
+- Adding fields to `AttendanceEvent` is a contract change and should be
+  introduced through a scoped issue.
+- Renaming current payload keys is a contract migration and must include backend
+  compatibility planning.
+- Broadening or changing `EventType` wire values must be documented so consumers
+  can decide whether to reject, ignore, or handle the new value.
 
 ## Versioning
 
-Versioning is currently documentation-level only. This contract does not define a runtime `schema_version`
-field.
+Versioning is currently documentation-level only. This contract does not define
+a runtime `schema_version` field.
 
-A future runtime `schema_version` may be introduced if multiple incompatible canonical event shapes need to
-coexist. Until then, changes to this contract are governed by repository review and the repository changelog or
-commit history.
-
-## Minimal Payload
-
-```json
-{
-  "event_id": "att-dev-dk-01-10042-2026-05-27T08:59:12Z",
-  "source_device_id": "att-dev-dk-01",
-  "employee_id": "10042",
-  "event_timestamp": "2026-05-27T08:59:12Z",
-  "event_type": "clock_in",
-  "ingested_at": "2026-05-27T09:00:03Z"
-}
-```
-
-## Full Payload
-
-```json
-{
-  "event_id": "att-dev-dk-01-10042-2026-05-27T08:59:12Z",
-  "source_device_id": "att-dev-dk-01",
-  "employee_id": "10042",
-  "event_timestamp": "2026-05-27T08:59:12Z",
-  "event_type": "clock_in",
-  "ingested_at": "2026-05-27T09:00:03Z",
-  "source_record_id": "zk-879221",
-  "employee_name": "Ayesha Khan",
-  "site_id": "dk",
-  "raw_event_type": "Check In",
-  "metadata": {
-    "source_format": "zkteco",
-    "source_timezone": "Asia/Karachi"
-  }
-}
-```
+A future runtime `schema_version` may be introduced if multiple incompatible
+canonical event shapes need to coexist. Until then, changes to this contract are
+governed by repository review and the repository changelog or commit history.
 
 ## Non-Goals
 
 - This document defines the canonical attendance event contract only.
+- ETLP-30 does not introduce a richer canonical wire schema.
 - Runtime validation and enforcement are future work.
 - Device-specific raw payload formats are outside this document.

--- a/docs/decisions/0003-device-and-transformation-layer-boundaries.md
+++ b/docs/decisions/0003-device-and-transformation-layer-boundaries.md
@@ -376,6 +376,8 @@ and:
         punch: EventType
         timestamp: datetime
 
+`EventType` is a project-owned domain enumeration shared by `NormalisedAttendance` and `AttendanceEvent`.
+
 `NormalisedAttendance` is an internal transformation-layer model.
 
 It must not cross the transformation boundary.
@@ -394,6 +396,45 @@ Canonical attendance events shall include:
 - `employee`
 - `event_type`
 - `timestamp`
+
+`site_id` originates from the commissioned `BiometricDevice` instance and is propagated through the transformation layer.
+
+The lineage is:
+
+    BiometricDeviceConfig.site_id
+        ↓
+    BiometricDevice.site_id
+        ↓
+    AttendanceEvent.site_id
+
+### ETLP-30 Pub/Sub Payload Compatibility Addendum
+
+ETLP-30 makes the internal `AttendanceEvent` model canonical, but intentionally
+preserves backend-compatible Pub/Sub serialisation.
+
+The current wire payload remains transitional/backend-compatible:
+
+    {
+        "username": self.employee.name,
+        "timestamp": self.timestamp.strftime(ATTENDANCE_TIMESTAMP_FORMAT),
+        "entry": self.event_type.value,
+        "device": self.site_id,
+    }
+
+`EventType` values use `"Check In"` and `"Check Out"` for current backend
+compatibility.
+
+Richer canonical payload metadata is deferred to later contract migration work.
+Deferred items include:
+
+- `event_id`
+- `ingested_at`
+- `event_timestamp` as the future canonical wire-payload timestamp name
+- `source_device_id`
+- timezone-aware timestamp semantics
+- future `"Clock In"` and `"Clock Out"` EventType wire values
+
+`source_device_id` is intentionally excluded from the ETLP-30 `AttendanceEvent` contract despite being considered a future provenance attribute.
 
 ### Rationale
 

--- a/src/attendance_etl/models/attendance_event.py
+++ b/src/attendance_etl/models/attendance_event.py
@@ -1,78 +1,43 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict
+
+from attendance_etl.models.employee import Employee
+from attendance_etl.models.interfaces import ISerializable
 
 ATTENDANCE_TIMESTAMP_FORMAT = "%d-%m-%Y %H:%M:%S"
 
 
+# TODO: These values preserve backend-compatible Pub/Sub payloads. Future
+# canonical contract migration should change them to "Clock In" and "Clock Out"
+# through a dedicated contract migration issue.
 class EventType(Enum):
-    CLOCK_IN = "CLOCK_IN"
-    CLOCK_OUT = "CLOCK_OUT"
+    CLOCK_IN = "Check In"
+    CLOCK_OUT = "Check Out"
 
 
-def _parse_datetime(value: str) -> datetime:
-    try:
-        return datetime.strptime(value, ATTENDANCE_TIMESTAMP_FORMAT)
-    except ValueError:
-        pass
+@dataclass(frozen=True)
+class AttendanceEvent(ISerializable):
+    """Canonical attendance event produced by the transformation layer."""
 
-    if value.endswith("Z"):
-        value = value[:-1] + "+00:00"
-    return datetime.fromisoformat(value)
-
-
-@dataclass
-class AttendanceEvent:
-    """Attendance event model prepared for current and canonical payloads."""
-
-    source_device_id: str
-    event_timestamp: datetime
-    employee_name: Optional[str] = None
-    raw_event_type: Optional[str] = None
-    employee_id: Optional[str] = None
-    event_type: Optional[str] = None
-    event_id: Optional[str] = None
-    ingested_at: Optional[datetime] = None
-    source_record_id: Optional[str] = None
-    site_id: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    site_id: str
+    employee: Employee
+    event_type: EventType
+    timestamp: datetime
 
     def to_dict(self) -> Dict[str, Any]:
+        # TODO: This serialises to the legacy backend-compatible Pub/Sub shape:
+        # {"username": ..., "timestamp": ..., "entry": ..., "device": ...}.
+        # Long-term contract evolution should rename "timestamp" to
+        # "event_timestamp", add "event_id", "ingested_at", and
+        # "source_device_id", and preserve timezone information for event
+        # timestamps. These changes are intentionally deferred to later
+        # transformation/messaging-layer work and must be introduced through a
+        # dedicated contract migration.
         return {
-            "username": self.employee_name,
-            "timestamp": self.event_timestamp.strftime(ATTENDANCE_TIMESTAMP_FORMAT),
-            "entry": self.raw_event_type or self.event_type,
-            "device": self.source_device_id,
+            "username": self.employee.name,
+            "timestamp": self.timestamp.strftime(ATTENDANCE_TIMESTAMP_FORMAT),
+            "entry": self.event_type.value,
+            "device": self.site_id,
         }
-
-    @classmethod
-    def from_dict(cls, payload: Dict[str, Any]) -> "AttendanceEvent":
-        if "timestamp" in payload:
-            return cls(
-                source_device_id=payload["device"],
-                event_timestamp=_parse_datetime(payload["timestamp"]),
-                employee_name=payload.get("username"),
-                raw_event_type=payload.get("entry"),
-                event_type=payload.get("event_type"),
-                employee_id=payload.get("employee_id"),
-                event_id=payload.get("event_id"),
-                ingested_at=_parse_datetime(payload["ingested_at"]) if payload.get("ingested_at") else None,
-                source_record_id=payload.get("source_record_id"),
-                site_id=payload.get("site_id"),
-                metadata=dict(payload.get("metadata", {})),
-            )
-
-        return cls(
-            source_device_id=payload["source_device_id"],
-            event_timestamp=_parse_datetime(payload["event_timestamp"]),
-            employee_name=payload.get("employee_name"),
-            raw_event_type=payload.get("raw_event_type"),
-            employee_id=payload.get("employee_id"),
-            event_type=payload.get("event_type"),
-            event_id=payload.get("event_id"),
-            ingested_at=_parse_datetime(payload["ingested_at"]) if payload.get("ingested_at") else None,
-            source_record_id=payload.get("source_record_id"),
-            site_id=payload.get("site_id"),
-            metadata=dict(payload.get("metadata", {})),
-        )

--- a/tests/unit/ingestion/test_models.py
+++ b/tests/unit/ingestion/test_models.py
@@ -1,16 +1,19 @@
 import unittest
 from datetime import datetime
+from typing import runtime_checkable
 
-from attendance_etl.models import AttendanceEvent, Employee, ISerializable, ReviewPeriod, RuntimeState
+from attendance_etl.models import AttendanceEvent, Employee, EventType, ISerializable, ReviewPeriod, RuntimeState
+
+ISerializable = runtime_checkable(ISerializable)
 
 
 class DomainModelTests(unittest.TestCase):
     def test_attendance_event_to_dict_preserves_current_backend_payload_shape(self):
         event = AttendanceEvent(
-            source_device_id="att-dev-dk-01",
-            event_timestamp=datetime(2026, 5, 27, 8, 59, 12),
-            employee_name="Ayesha Khan",
-            raw_event_type="Check In",
+            site_id="att-dev-dk-01",
+            employee=Employee(id="10042", name="Ayesha Khan"),
+            event_type=EventType.CLOCK_IN,
+            timestamp=datetime(2026, 5, 27, 8, 59, 12),
         )
 
         self.assertEqual(
@@ -23,51 +26,50 @@ class DomainModelTests(unittest.TestCase):
             },
         )
 
-    def test_attendance_event_from_dict_accepts_current_backend_payload_shape(self):
-        event = AttendanceEvent.from_dict(
-            {
-                "username": "Ayesha Khan",
-                "timestamp": "2026-05-27T08:59:12Z",
-                "entry": "Check In",
-                "device": "att-dev-dk-01",
-            }
-        )
-
-        self.assertEqual(event.employee_name, "Ayesha Khan")
-        self.assertEqual(event.event_timestamp.isoformat(), "2026-05-27T08:59:12+00:00")
-        self.assertEqual(event.raw_event_type, "Check In")
-        self.assertEqual(event.source_device_id, "att-dev-dk-01")
-        self.assertIsNone(event.event_id)
-        self.assertIsNone(event.employee_id)
-        self.assertIsNone(event.ingested_at)
-        self.assertEqual(event.metadata, {})
-
-    def test_attendance_event_model_retains_internal_semantics(self):
+    def test_attendance_event_contract_contains_only_canonical_fields(self):
+        employee = Employee(id="10042", name="Ayesha Khan")
         event = AttendanceEvent(
-            source_device_id="att-dev-dk-01",
-            event_timestamp=datetime(2026, 5, 27, 8, 59, 12),
-            employee_name="Ayesha Khan",
-            raw_event_type="Check In",
-            employee_id="10042",
-            event_type="clock_in",
-            event_id="att-dev-dk-01-10042-2026-05-27T08:59:12Z",
-            ingested_at=datetime(2026, 5, 27, 9, 0, 3),
-            source_record_id="zk-879221",
-            site_id="dk",
-            metadata={"source_format": "zkteco"},
+            site_id="att-dev-dk-01",
+            employee=employee,
+            event_type=EventType.CLOCK_OUT,
+            timestamp=datetime(2026, 5, 27, 17, 45, 3),
         )
 
-        self.assertEqual(event.event_id, "att-dev-dk-01-10042-2026-05-27T08:59:12Z")
-        self.assertEqual(event.source_device_id, "att-dev-dk-01")
-        self.assertEqual(event.employee_id, "10042")
-        self.assertEqual(event.event_timestamp, datetime(2026, 5, 27, 8, 59, 12))
-        self.assertEqual(event.event_type, "clock_in")
-        self.assertEqual(event.ingested_at, datetime(2026, 5, 27, 9, 0, 3))
-        self.assertEqual(event.source_record_id, "zk-879221")
-        self.assertEqual(event.employee_name, "Ayesha Khan")
-        self.assertEqual(event.site_id, "dk")
-        self.assertEqual(event.raw_event_type, "Check In")
-        self.assertEqual(event.metadata, {"source_format": "zkteco"})
+        self.assertTrue(issubclass(AttendanceEvent, ISerializable))
+        self.assertEqual(event.site_id, "att-dev-dk-01")
+        self.assertIs(event.employee, employee)
+        self.assertEqual(event.event_type, EventType.CLOCK_OUT)
+        self.assertEqual(event.timestamp, datetime(2026, 5, 27, 17, 45, 3))
+        self.assertEqual(
+            set(event.__dataclass_fields__),
+            {"site_id", "employee", "event_type", "timestamp"},
+        )
+        self.assertFalse(hasattr(AttendanceEvent, "from_dict"))
+
+    def test_attendance_event_contract_removes_legacy_fields(self):
+        event = AttendanceEvent(
+            site_id="att-dev-dk-01",
+            employee=Employee(id="10042", name="Ayesha Khan"),
+            event_type=EventType.CLOCK_IN,
+            timestamp=datetime(2026, 5, 27, 8, 59, 12),
+        )
+
+        for field_name in (
+            "source_device_id",
+            "event_timestamp",
+            "employee_name",
+            "raw_event_type",
+            "employee_id",
+            "event_id",
+            "ingested_at",
+            "source_record_id",
+            "metadata",
+        ):
+            self.assertFalse(hasattr(event, field_name))
+
+    def test_event_type_values_preserve_backend_payload_contract(self):
+        self.assertEqual(EventType.CLOCK_IN.value, "Check In")
+        self.assertEqual(EventType.CLOCK_OUT.value, "Check Out")
 
     def test_employee_contract_contains_only_normalised_identity(self):
         employee = Employee(id="10042", name="Ayesha Khan")

--- a/tests/unit/ingestion/test_transformation_foundation.py
+++ b/tests/unit/ingestion/test_transformation_foundation.py
@@ -9,8 +9,8 @@ from attendance_etl.transform import ExtractedBiometricData, NormalisedAttendanc
 
 class TransformationFoundationTests(unittest.TestCase):
     def test_event_type_values_are_vendor_neutral(self):
-        self.assertEqual(EventType.CLOCK_IN.value, "CLOCK_IN")
-        self.assertEqual(EventType.CLOCK_OUT.value, "CLOCK_OUT")
+        self.assertEqual(EventType.CLOCK_IN.value, "Check In")
+        self.assertEqual(EventType.CLOCK_OUT.value, "Check Out")
         self.assertEqual(set(EventType), {EventType.CLOCK_IN, EventType.CLOCK_OUT})
 
     def test_extracted_biometric_data_structure_groups_raw_device_data(self):


### PR DESCRIPTION
<!--
planning_metadata:
  estimated_effort: 2.5h
  priority: Highest
  milestone_id: 4
  milestone: "4. Transformation Layer"
-->

## Summary

Introduces the canonical AttendanceEvent model:

```python
AttendanceEvent(
    site_id: str,
    employee: Employee,
    event_type: EventType,
    timestamp: datetime,
)
```

## Changes

- Replaces the legacy AttendanceEvent implementation with the Milestone 4 canonical model
- Preserves backend-compatible Pub/Sub serialisation behaviour
- Preserves the attendance timestamp serialisation contract
- Removes legacy deserialisation and transitional AttendanceEvent fields
- Documents deferred canonical payload evolution
- Records ETLP-30 compatibility decisions in ADR-0003

## Acceptance criteria

- [x] Existing `AttendanceEvent` implementation is discarded completely except for the timestamp serialisation contract
- [x] `AttendanceEvent` contains only `site_id`, `employee`, `event_type`, and `timestamp`
- [x] `AttendanceEvent`: 
   - composes `Employee`
   - `event_type` uses `EventType`
   - implements `ISerializable`
- [x] `AttendanceEvent.to_dict()` preserves the Pub/Sub payload shape
- [x] Timestamp serialisation uses `ATTENDANCE_TIMESTAMP_FORMAT = "%d-%m-%Y %H:%M:%S"`
- [x] `AttendanceEvent` no longer has any of the following: 
   - `from_dict(...)` implementation
   - `IDeserializable` implementation exists
   - legacy transitional payload support exists
   - `raw_event_type` field exists
   - `source_device_id` field exists
   - `metadata` field exists
   - `employee_id` field exists
   - `employee_name` field exists
