### PR TITLE
ETLP-31: introduces transformation strategy template method

### DIFF
--- a/src/attendance_etl/transform/__init__.py
+++ b/src/attendance_etl/transform/__init__.py
@@ -1,11 +1,13 @@
 """Transformation-layer foundation models and source-record helpers."""
 
 from attendance_etl.transform.normalised_attendance import NormalisedAttendance
+from attendance_etl.transform.transformation_strategy import TransformationStrategy
 from attendance_etl.transform.transformation_request import ExtractedBiometricData, TimeRange, TransformationRequest
 
 __all__ = [
     "ExtractedBiometricData",
     "NormalisedAttendance",
     "TimeRange",
+    "TransformationStrategy",
     "TransformationRequest",
 ]

--- a/src/attendance_etl/transform/transformation_strategy.py
+++ b/src/attendance_etl/transform/transformation_strategy.py
@@ -1,0 +1,72 @@
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import List, Sequence
+
+from attendance_etl.models import AttendanceEvent, EventType
+from attendance_etl.transform.normalised_attendance import NormalisedAttendance
+from attendance_etl.transform.transformation_request import ExtractedBiometricData, TimeRange, TransformationRequest
+
+
+class TransformationStrategy(ABC):
+    """Template method base class for biometric attendance transformation."""
+
+    def transform(self, request: TransformationRequest) -> List[AttendanceEvent]:
+        normalised_attendance = self.normalise(request.raw_data)
+        self.validate(normalised_attendance)
+        attendance_events = self.canonicalise(normalised_attendance, request.site_id)
+        return self.filter(attendance_events, request.time_range)
+
+    @abstractmethod
+    def normalise(self, raw_data: ExtractedBiometricData) -> List[NormalisedAttendance]:
+        raise NotImplementedError
+
+    def validate(self, attendance: Sequence[NormalisedAttendance]) -> None:
+        for index, attendance_record in enumerate(attendance):
+            if not isinstance(attendance_record, NormalisedAttendance):
+                raise ValueError("attendance[{}] must be NormalisedAttendance".format(index))
+
+            employee_id = getattr(attendance_record.employee, "id", None)
+            if not isinstance(employee_id, str) or employee_id == "":
+                raise ValueError("attendance[{}].employee.id must be a non-empty string".format(index))
+
+            employee_name = getattr(attendance_record.employee, "name", None)
+            if not isinstance(employee_name, str) or employee_name == "":
+                raise ValueError("attendance[{}].employee.name must be a non-empty string".format(index))
+
+            if not isinstance(attendance_record.punch, EventType):
+                raise ValueError("attendance[{}].punch must be EventType".format(index))
+
+            if not isinstance(attendance_record.timestamp, datetime):
+                raise ValueError("attendance[{}].timestamp must be datetime".format(index))
+
+    def canonicalise(
+        self,
+        attendance: Sequence[NormalisedAttendance],
+        site_id: str,
+    ) -> List[AttendanceEvent]:
+        return [
+            AttendanceEvent(
+                site_id=site_id,
+                employee=attendance_record.employee,
+                event_type=attendance_record.punch,
+                timestamp=attendance_record.timestamp,
+            )
+            for attendance_record in attendance
+        ]
+
+    def filter(
+        self,
+        attendance_events: Sequence[AttendanceEvent],
+        time_range: TimeRange,
+    ) -> List[AttendanceEvent]:
+        effective_end_time = time_range.end_time if time_range.end_time is not None else datetime.now()
+        filtered_events = []
+
+        for index, attendance_event in enumerate(attendance_events):
+            if not isinstance(attendance_event, AttendanceEvent):
+                raise ValueError("attendance_events[{}] must be AttendanceEvent".format(index))
+
+            if time_range.start_time <= attendance_event.timestamp <= effective_end_time:
+                filtered_events.append(attendance_event)
+
+        return filtered_events

--- a/tests/unit/ingestion/test_transformation_strategy.py
+++ b/tests/unit/ingestion/test_transformation_strategy.py
@@ -1,0 +1,225 @@
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from attendance_etl.models import AttendanceEvent, Employee, EventType
+from attendance_etl.transform import (
+    ExtractedBiometricData,
+    NormalisedAttendance,
+    TimeRange,
+    TransformationRequest,
+    TransformationStrategy,
+)
+
+
+class ConcreteTransformationStrategy(TransformationStrategy):
+    def __init__(self, normalised_attendance=None):
+        self.normalised_attendance = normalised_attendance or []
+
+    def normalise(self, raw_data):
+        return list(self.normalised_attendance)
+
+
+class TransformationStrategyTests(unittest.TestCase):
+    def test_transform_calls_stages_in_order(self):
+        employee = Employee(id="10042", name="Ayesha Khan")
+        timestamp = datetime(2026, 5, 27, 8, 59, 12)
+        normalised_attendance = [NormalisedAttendance(employee=employee, punch=EventType.CLOCK_IN, timestamp=timestamp)]
+        attendance_events = [
+            AttendanceEvent(
+                site_id="dk",
+                employee=employee,
+                event_type=EventType.CLOCK_IN,
+                timestamp=timestamp,
+            )
+        ]
+        test_case = self
+
+        class RecordingTransformationStrategy(TransformationStrategy):
+            def __init__(self):
+                self.calls = []
+
+            def normalise(self, raw_data):
+                self.calls.append("normalise")
+                return normalised_attendance
+
+            def validate(self, attendance):
+                self.calls.append("validate")
+                test_case.assertIs(attendance, normalised_attendance)
+
+            def canonicalise(self, attendance, site_id):
+                self.calls.append("canonicalise")
+                test_case.assertIs(attendance, normalised_attendance)
+                test_case.assertEqual(site_id, "dk")
+                return attendance_events
+
+            def filter(self, attendance_events_to_filter, time_range):
+                self.calls.append("filter")
+                test_case.assertIs(attendance_events_to_filter, attendance_events)
+                return attendance_events_to_filter
+
+        strategy = RecordingTransformationStrategy()
+        request = TransformationRequest(
+            raw_data=ExtractedBiometricData(employees=[], attendance_records=[]),
+            site_id="dk",
+            time_range=TimeRange(start_time=datetime(2026, 5, 27, 0, 0, 0)),
+        )
+
+        self.assertEqual(strategy.transform(request), attendance_events)
+        self.assertEqual(strategy.calls, ["normalise", "validate", "canonicalise", "filter"])
+
+    def test_normalise_is_abstract_and_must_be_implemented_by_subclasses(self):
+        with self.assertRaises(TypeError):
+            TransformationStrategy()
+
+    def test_validate_accepts_valid_normalised_attendance(self):
+        attendance = [
+            NormalisedAttendance(
+                employee=Employee(id="10042", name="Ayesha Khan"),
+                punch=EventType.CLOCK_IN,
+                timestamp=datetime(2026, 5, 27, 8, 59, 12),
+            )
+        ]
+
+        ConcreteTransformationStrategy().validate(attendance)
+
+    def test_validate_rejects_non_normalised_attendance(self):
+        with self.assertRaisesRegex(ValueError, "NormalisedAttendance"):
+            ConcreteTransformationStrategy().validate([object()])
+
+    def test_validate_rejects_empty_employee_id(self):
+        attendance = [
+            NormalisedAttendance(
+                employee=Employee(id="", name="Ayesha Khan"),
+                punch=EventType.CLOCK_IN,
+                timestamp=datetime(2026, 5, 27, 8, 59, 12),
+            )
+        ]
+
+        with self.assertRaisesRegex(ValueError, "employee.id"):
+            ConcreteTransformationStrategy().validate(attendance)
+
+    def test_validate_rejects_empty_employee_name(self):
+        attendance = [
+            NormalisedAttendance(
+                employee=Employee(id="10042", name=""),
+                punch=EventType.CLOCK_IN,
+                timestamp=datetime(2026, 5, 27, 8, 59, 12),
+            )
+        ]
+
+        with self.assertRaisesRegex(ValueError, "employee.name"):
+            ConcreteTransformationStrategy().validate(attendance)
+
+    def test_validate_rejects_non_event_type_punch(self):
+        attendance = [
+            NormalisedAttendance(
+                employee=Employee(id="10042", name="Ayesha Khan"),
+                punch="Check In",
+                timestamp=datetime(2026, 5, 27, 8, 59, 12),
+            )
+        ]
+
+        with self.assertRaisesRegex(ValueError, "EventType"):
+            ConcreteTransformationStrategy().validate(attendance)
+
+    def test_validate_rejects_non_datetime_timestamp(self):
+        attendance = [
+            NormalisedAttendance(
+                employee=Employee(id="10042", name="Ayesha Khan"),
+                punch=EventType.CLOCK_IN,
+                timestamp="27-05-2026 08:59:12",
+            )
+        ]
+
+        with self.assertRaisesRegex(ValueError, "datetime"):
+            ConcreteTransformationStrategy().validate(attendance)
+
+    def test_canonicalise_produces_attendance_event(self):
+        attendance = [
+            NormalisedAttendance(
+                employee=Employee(id="10042", name="Ayesha Khan"),
+                punch=EventType.CLOCK_IN,
+                timestamp=datetime(2026, 5, 27, 8, 59, 12),
+            )
+        ]
+
+        events = ConcreteTransformationStrategy().canonicalise(attendance, "dk")
+
+        self.assertEqual(len(events), 1)
+        self.assertIsInstance(events[0], AttendanceEvent)
+
+    def test_canonicalise_maps_site_id_employee_punch_and_timestamp_exactly(self):
+        employee = Employee(id="10042", name="Ayesha Khan")
+        timestamp = datetime(2026, 5, 27, 8, 59, 12)
+        attendance = [NormalisedAttendance(employee=employee, punch=EventType.CLOCK_OUT, timestamp=timestamp)]
+
+        event = ConcreteTransformationStrategy().canonicalise(attendance, "att-dev-dk-01")[0]
+
+        self.assertEqual(event.site_id, "att-dev-dk-01")
+        self.assertIs(event.employee, employee)
+        self.assertEqual(event.event_type, EventType.CLOCK_OUT)
+        self.assertIs(event.timestamp, timestamp)
+
+    def test_filter_uses_inclusive_boundaries(self):
+        employee = Employee(id="10042", name="Ayesha Khan")
+        before_start = AttendanceEvent("dk", employee, EventType.CLOCK_IN, datetime(2026, 5, 27, 7, 59, 59))
+        at_start = AttendanceEvent("dk", employee, EventType.CLOCK_IN, datetime(2026, 5, 27, 8, 0, 0))
+        middle = AttendanceEvent("dk", employee, EventType.CLOCK_OUT, datetime(2026, 5, 27, 12, 0, 0))
+        at_end = AttendanceEvent("dk", employee, EventType.CLOCK_OUT, datetime(2026, 5, 27, 17, 0, 0))
+        after_end = AttendanceEvent("dk", employee, EventType.CLOCK_OUT, datetime(2026, 5, 27, 17, 0, 1))
+        time_range = TimeRange(
+            start_time=datetime(2026, 5, 27, 8, 0, 0),
+            end_time=datetime(2026, 5, 27, 17, 0, 0),
+        )
+
+        filtered_events = ConcreteTransformationStrategy().filter(
+            [before_start, at_start, middle, at_end, after_end],
+            time_range,
+        )
+
+        self.assertEqual(filtered_events, [at_start, middle, at_end])
+
+    def test_filter_preserves_input_ordering(self):
+        employee = Employee(id="10042", name="Ayesha Khan")
+        later_event = AttendanceEvent("dk", employee, EventType.CLOCK_OUT, datetime(2026, 5, 27, 17, 0, 0))
+        earlier_event = AttendanceEvent("dk", employee, EventType.CLOCK_IN, datetime(2026, 5, 27, 8, 0, 0))
+        middle_event = AttendanceEvent("dk", employee, EventType.CLOCK_OUT, datetime(2026, 5, 27, 12, 0, 0))
+        events = [later_event, earlier_event, middle_event]
+        time_range = TimeRange(
+            start_time=datetime(2026, 5, 27, 0, 0, 0),
+            end_time=datetime(2026, 5, 27, 23, 59, 59),
+        )
+
+        filtered_events = ConcreteTransformationStrategy().filter(events, time_range)
+
+        self.assertEqual(filtered_events, events)
+
+    def test_filter_uses_datetime_now_when_time_range_end_time_is_none(self):
+        employee = Employee(id="10042", name="Ayesha Khan")
+        included_event = AttendanceEvent("dk", employee, EventType.CLOCK_IN, datetime(2026, 5, 27, 9, 0, 0))
+        future_event = AttendanceEvent("dk", employee, EventType.CLOCK_OUT, datetime(2026, 5, 27, 10, 0, 1))
+        time_range = TimeRange(start_time=datetime(2026, 5, 27, 8, 0, 0))
+
+        with patch("attendance_etl.transform.transformation_strategy.datetime") as datetime_mock:
+            datetime_mock.now.return_value = datetime(2026, 5, 27, 10, 0, 0)
+
+            filtered_events = ConcreteTransformationStrategy().filter([included_event, future_event], time_range)
+
+        datetime_mock.now.assert_called_once_with()
+        self.assertEqual(filtered_events, [included_event])
+
+    def test_filter_rejects_raw_sdk_records(self):
+        raw_sdk_record = SimpleNamespace(timestamp=datetime(2026, 5, 27, 9, 0, 0))
+        time_range = TimeRange(
+            start_time=datetime(2026, 5, 27, 8, 0, 0),
+            end_time=datetime(2026, 5, 27, 10, 0, 0),
+        )
+
+        with self.assertRaisesRegex(ValueError, "AttendanceEvent"):
+            ConcreteTransformationStrategy().filter([raw_sdk_record], time_range)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces the base transformation abstraction:

```text
normalise
    ↓
validate
    ↓
canonicalise
    ↓
filter
```

The pipeline is orchestrated through:

```py
transform(request: TransformationRequest)
```

which acts as the Template Method.

## Changes

- Introduces the vendor-neutral `TransformationStrategy` abstraction
- Implements the transformation pipeline template method
- Adds vendor-neutral validation, canonicalisation, and filtering behaviour
- Establishes the transformation-layer execution contract for future vendor implementations
- Adds focused unit tests for pipeline behaviour and contract enforcement


## Acceptance criteria

- [x] Pipeline order is `normalise -> validate -> canonicalise -> filter`
- [x] `transform(...)` acts as the Template Method
- [x] Validation operates on `NormalisedAttendance`
- [x] Invalid `NormalisedAttendance` records raise `ValueError`
- [x] Canonicalisation produces `AttendanceEvent`
- [x] Filtering:
  - operates only on canonical `AttendanceEvent` objects
  - preserves input ordering
  - operates on the rule: `attendance_event.timestamp in Range [start_time, effective_end_time]`
  - `TimeRange.end_time=None` resolves to `datetime.now()` inside `TransformationStrategy.filter(...)`
- [x] `TimeRange` remains a passive data structure
- [x] `site_id` is sourced from `TransformationRequest`
- [x] Base strategy remains vendor-neutral